### PR TITLE
[Spring JDBC 2주차] 최준호 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
 }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -2,9 +2,7 @@ package roomescape.controller;
 
 import jakarta.validation.Valid;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,19 +13,16 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 import roomescape.controller.dto.CreateReservation;
 import roomescape.controller.dto.ReservationResponse;
-import roomescape.dao.ReservationDao;
 import roomescape.domain.Reservation;
+import roomescape.service.ReservationService;
 
 @Controller
 public class ReservationController {
 
-    private final AtomicLong id = new AtomicLong();
-    private final List<Reservation> reservations = new ArrayList<>();
+    private final ReservationService reservationService;
 
-    private final ReservationDao reservationDao;
-
-    public ReservationController(ReservationDao reservationDao) {
-        this.reservationDao = reservationDao;
+    public ReservationController(ReservationService reservationService) {
+        this.reservationService = reservationService;
     }
 
     @GetMapping("/reservation")
@@ -38,26 +33,20 @@ public class ReservationController {
     @GetMapping("/reservations")
     @ResponseBody
     public List<ReservationResponse> reservations() {
-        return reservationDao.findAll().stream()
+        return reservationService.findAll().stream()
             .map(ReservationResponse::from)
             .toList();
     }
 
     @PostMapping("/reservations")
     public ResponseEntity<Reservation> create(@Valid @RequestBody CreateReservation request) {
-        Reservation reservation = request.toReservation(id.incrementAndGet());
-        reservations.add(reservation);
+        Reservation reservation = reservationService.create(request);
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
     }
 
     @DeleteMapping("/reservations/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
-        Reservation reservation = reservations.stream()
-            .filter(it -> it.getId() == id)
-            .findAny()
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약입니다."));
-
-        reservations.remove(reservation);
+        reservationService.remove(id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 import roomescape.controller.dto.CreateReservation;
 import roomescape.controller.dto.ReservationResponse;
+import roomescape.dao.ReservationDao;
 import roomescape.domain.Reservation;
 
 @Controller
@@ -23,15 +24,21 @@ public class ReservationController {
     private final AtomicLong id = new AtomicLong();
     private final List<Reservation> reservations = new ArrayList<>();
 
+    private final ReservationDao reservationDao;
+
+    public ReservationController(ReservationDao reservationDao) {
+        this.reservationDao = reservationDao;
+    }
+
     @GetMapping("/reservation")
     public String reservationPage() {
-        return "reservation.html";
+        return "reservation";
     }
 
     @GetMapping("/reservations")
     @ResponseBody
     public List<ReservationResponse> reservations() {
-        return reservations.stream()
+        return reservationDao.findAll().stream()
             .map(ReservationResponse::from)
             .toList();
     }

--- a/src/main/java/roomescape/controller/dto/CreateReservation.java
+++ b/src/main/java/roomescape/controller/dto/CreateReservation.java
@@ -13,7 +13,7 @@ public record CreateReservation(
     @NotNull @DateTimeFormat(pattern = "hh:mm") LocalTime time
 ) {
 
-    public Reservation toReservation(Long id) {
-        return new Reservation(id, name, date, time);
+    public Reservation toReservation() {
+        return new Reservation(null, name, date, time);
     }
 }

--- a/src/main/java/roomescape/dao/JdbcReservationDao.java
+++ b/src/main/java/roomescape/dao/JdbcReservationDao.java
@@ -1,8 +1,12 @@
 package roomescape.dao;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 import roomescape.domain.Reservation;
 
@@ -23,7 +27,40 @@ public class JdbcReservationDao implements ReservationDao {
     }
 
     @Override
+    public Reservation save(Reservation reservation) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update((Connection con) -> {
+            PreparedStatement pstmt = con.prepareStatement(
+                "INSERT INTO reservation(name, date, time) VALUES (?, ?, ?)", new String[]{"ID"});
+            pstmt.setString(1, reservation.getName());
+            pstmt.setString(2, reservation.getDate().toString());
+            pstmt.setString(3, reservation.getTime().toString());
+            return pstmt;
+        }, keyHolder);
+
+        Number key = keyHolder.getKey();
+        if (key == null) {
+            throw new IllegalStateException("키 생성 실패");
+        }
+        return new Reservation(key.longValue(), reservation.getName(), reservation.getDate(), reservation.getTime());
+    }
+
+    @Override
     public List<Reservation> findAll() {
         return jdbcTemplate.query("SELECT id, name, date, time FROM reservation", RESERVATION_ROW_MAPPER);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        jdbcTemplate.update("DELETE FROM reservation WHERE id = ?", id);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        Long result = jdbcTemplate.queryForObject("select count(*) from reservation where id = ?", Long.class, id);
+        if (result == null) {
+            return false;
+        }
+        return result > 0;
     }
 }

--- a/src/main/java/roomescape/dao/JdbcReservationDao.java
+++ b/src/main/java/roomescape/dao/JdbcReservationDao.java
@@ -1,0 +1,29 @@
+package roomescape.dao;
+
+import java.util.List;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import roomescape.domain.Reservation;
+
+@Repository
+public class JdbcReservationDao implements ReservationDao {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private static final RowMapper<Reservation> RESERVATION_ROW_MAPPER = (resultSet, rowNum) -> new Reservation(
+        resultSet.getLong("id"),
+        resultSet.getString("name"),
+        resultSet.getDate("date").toLocalDate(),
+        resultSet.getTime("time").toLocalTime()
+    );
+
+    public JdbcReservationDao(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public List<Reservation> findAll() {
+        return jdbcTemplate.query("SELECT id, name, date, time FROM reservation", RESERVATION_ROW_MAPPER);
+    }
+}

--- a/src/main/java/roomescape/dao/ReservationDao.java
+++ b/src/main/java/roomescape/dao/ReservationDao.java
@@ -1,0 +1,9 @@
+package roomescape.dao;
+
+import java.util.List;
+import roomescape.domain.Reservation;
+
+public interface ReservationDao {
+
+    List<Reservation> findAll();
+}

--- a/src/main/java/roomescape/dao/ReservationDao.java
+++ b/src/main/java/roomescape/dao/ReservationDao.java
@@ -5,5 +5,11 @@ import roomescape.domain.Reservation;
 
 public interface ReservationDao {
 
+    Reservation save(Reservation reservation);
+
     List<Reservation> findAll();
+
+    void deleteById(Long id);
+
+    boolean existsById(Long id);
 }

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -6,19 +6,19 @@ import java.util.Objects;
 
 public class Reservation {
 
-    private final long id;
+    private final Long id;
     private final String name;
     private final LocalDate date;
     private final LocalTime time;
 
-    public Reservation(long id, String name, LocalDate date, LocalTime time) {
+    public Reservation(Long id, String name, LocalDate date, LocalTime time) {
         this.id = id;
         this.name = name;
         this.date = date;
         this.time = time;
     }
 
-    public long getId() {
+    public Long getId() {
         return id;
     }
 

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -1,0 +1,37 @@
+package roomescape.service;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import roomescape.controller.dto.CreateReservation;
+import roomescape.dao.ReservationDao;
+import roomescape.domain.Reservation;
+
+@Service
+@Transactional(readOnly = true)
+public class ReservationService {
+
+    private final ReservationDao reservationDao;
+
+    public ReservationService(ReservationDao reservationDao) {
+        this.reservationDao = reservationDao;
+    }
+
+    public List<Reservation> findAll() {
+        return reservationDao.findAll();
+    }
+
+    @Transactional
+    public Reservation create(CreateReservation request) {
+        Reservation reservation = request.toReservation();
+        return reservationDao.save(reservation);
+    }
+
+    @Transactional
+    public void remove(Long id) {
+        if(!reservationDao.existsById(id)) {
+            throw new IllegalArgumentException("예약이 존재하지 않습니다.");
+        }
+        reservationDao.deleteById(id);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.datasource.url=jdbc:h2:mem:database

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE reservation
+(
+    id      BIGINT       NOT NULL AUTO_INCREMENT,
+    name    VARCHAR(255) NOT NULL,
+    date    VARCHAR(255) NOT NULL,
+    time    VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -131,4 +131,31 @@ class MissionStepTest {
 
         assertThat(reservations).hasSize(count);
     }
+
+    @Test
+    void 예약_추가_취소과정에_DB를_활용한다() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "2023-08-05");
+        params.put("time", "10:00");
+
+        RestAssured.given().log().all()
+            .contentType(ContentType.JSON)
+            .body(params)
+            .when().post("/reservations")
+            .then().log().all()
+            .statusCode(201)
+            .header("Location", "/reservations/1");
+
+        Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        assertThat(count).isEqualTo(1);
+
+        RestAssured.given().log().all()
+            .when().delete("/reservations/1")
+            .then().log().all()
+            .statusCode(204);
+
+        Integer countAfterDelete = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        assertThat(countAfterDelete).isZero();
+    }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -8,6 +8,7 @@ import io.restassured.http.ContentType;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -16,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.domain.Reservation;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -113,5 +115,20 @@ class MissionStepTest {
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    void 데이터베이스에_저장된_예약의_개수와_예약조회결과의_개수가_같다() {
+        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "브라운", "2023-08-05", "15:40");
+
+        List<Reservation> reservations = RestAssured.given().log().all()
+            .when().get("/reservations")
+            .then().log().all()
+            .statusCode(200).extract()
+            .jsonPath().getList(".", Reservation.class);
+
+        Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+
+        assertThat(reservations).hasSize(count);
     }
 }


### PR DESCRIPTION
## 🚀 작업 내용

- 예약을 조회, 생성, 삭제하는 과정에서 H2 DB를 사용하도록 수정했습니다.

## ✏️ 학습 내용

- 다음과 같은 키워드를 학습할 수 있었습니다.
  - try-with-resource
    - Spring이 관리해주는 영역
<img width="400px" alt="image" src="https://github.com/next-step/spring-roomescape-playground/assets/49794401/70ceb658-4a3c-4857-a8a4-c89a70a283c2">

  - jdbcTemplate KeyHolder
  - rowMapper
  - springBoot의 data.sql과 schema.sql
  - SQL 표준 문법
    - https://documentation.basis.cloud/BASISHelp/WebHelp/b3odbc/sql_grammar_bbjds.htm

## 💬 리뷰 중점사항

데이터를 저장하고 responseBody에 Reservation 정보를 반환해야하는 요구사항이 있었습니다.
이에 save 시 DAO에서 객체를 반환하는 방향을 고민했고 KeyHolder를 적용했습니다.