### PR TITLE
[Spring JDBC] 김원경 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    runtimeOnly 'com.h2database:h2'
     annotationProcessor('org.projectlombok:lombok')
     testAnnotationProcessor('org.projectlombok:lombok')
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -26,9 +26,9 @@ public class ReservationController {
     @PostMapping("/reservations")
     public ResponseEntity<Reservation> createReservation(@Valid @RequestBody ReservationDto reservationDto){
 
-        Reservation newReservation = reservationService.createReservation(reservationDto);
+        Long id = reservationService.createReservation(reservationDto);
 
-        return ResponseEntity.created(URI.create("/reservations/" + newReservation.getId())).body(newReservation);
+        return ResponseEntity.created(URI.create("/reservations/" + id)).build();
     }
 
     @DeleteMapping("/reservations/{id}")

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -1,27 +1,52 @@
 package roomescape.repository;
 
-import org.springframework.http.HttpStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 import roomescape.entity.Reservation;
 
-import java.util.ArrayList;
+import java.sql.PreparedStatement;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 @Repository
+@RequiredArgsConstructor
 public class ReservationRepository {
-    private final static List<Reservation> reservations = new ArrayList<>();
-    public final static AtomicLong index = new AtomicLong(1);
+    private final JdbcTemplate jdbcTemplate;
+
     public List<Reservation> findAll(){
+        List<Reservation> reservations = jdbcTemplate.query(
+                "select id, name, date, time from reservation",
+                (resultSet, rowNum) -> {
+                    Reservation reservation = Reservation.builder().
+                            id(resultSet.getLong("id")).
+                            name(resultSet.getString("name")).
+                            date(resultSet.getString("date")).
+                            time(resultSet.getString("time")).
+                            build();
+
+                    return reservation;
+                });
         return reservations;
     }
 
-    public Reservation createReservation(Reservation reservation){
-        reservations.add(reservation);
-        return reservation;
+    public Long createReservation(Reservation reservation){
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
+        jdbcTemplate.update(connection -> {
+            PreparedStatement ps = connection.prepareStatement(
+                    "INSERT INTO reservation(name, date, time) VALUES (?, ?, ?)", new String[]{"id"});
+            ps.setString(1, reservation.getName());
+            ps.setString(2, reservation.getDate());
+            ps.setString(3, reservation.getTime());
+            return ps;
+        }, keyHolder);
+
+        return keyHolder.getKey().longValue();
     }
 
-    public void deleteReservation(Reservation reservation){
-        reservations.remove(reservation);
+    public int deleteReservation(Long id){
+        return jdbcTemplate.update("delete from reservation where id = ?", id);
     }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public interface ReservationService {
     List<Reservation> findAll();
-    Reservation createReservation(ReservationDto reservationDto);
-    void deleteReservation(Long id);
+    Long createReservation(ReservationDto reservationDto);
+    int deleteReservation(Long id);
 }

--- a/src/main/java/roomescape/service/ReservationServiceImpl.java
+++ b/src/main/java/roomescape/service/ReservationServiceImpl.java
@@ -22,9 +22,8 @@ public class ReservationServiceImpl implements ReservationService{
     }
 
     @Override
-    public Reservation createReservation(ReservationDto reservationDto) {
+    public Long createReservation(ReservationDto reservationDto) {
         Reservation newReservation = Reservation.builder().
-                id(reservationRepository.index.getAndIncrement()).
                 name(reservationDto.getName()).
                 date(reservationDto.getDate()).
                 time(reservationDto.getTime()).build();
@@ -33,12 +32,12 @@ public class ReservationServiceImpl implements ReservationService{
     }
 
     @Override
-    public void deleteReservation(Long id) {
+    public int deleteReservation(Long id) {
         Reservation reservation = reservationRepository.findAll().stream()
                 .filter(existId -> Objects.equals(existId.getId(), id))
                 .findFirst()
                 .orElseThrow(()->new NotFoundReservationException("예약 정보를 찾을 수 없습니다."));
 
-        reservationRepository.deleteReservation(reservation);
+        return reservationRepository.deleteReservation(reservation.getId());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+# h2-console ??? ??
+spring.h2.console.enabled=true
+# db url
+spring.datasource.url=jdbc:h2:mem:database

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE reservation
+(
+    id      BIGINT       NOT NULL AUTO_INCREMENT,
+    name    VARCHAR(255) NOT NULL,
+    date    VARCHAR(255) NOT NULL,
+    time    VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -2,18 +2,31 @@ package roomescape;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.repository.ReservationRepository;
 
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.is;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @Test
     void 일단계() {
@@ -91,5 +104,16 @@ public class MissionStepTest {
                 .when().delete("/reservations/1")
                 .then().log().all()
                 .statusCode(400);
+    }
+
+    @Test
+    void 오단계() {
+        try (Connection connection = jdbcTemplate.getDataSource().getConnection()) {
+            Assertions.assertThat(connection).isNotNull();
+            Assertions.assertThat(connection.getCatalog()).isEqualTo("DATABASE");
+            Assertions.assertThat(connection.getMetaData().getTables(null, null, "RESERVATION", null).next()).isTrue();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -3,21 +3,18 @@ package roomescape;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
-import roomescape.repository.ReservationRepository;
+import roomescape.entity.Reservation;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.is;
 
@@ -115,5 +112,47 @@ public class MissionStepTest {
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    void 육단계() {
+        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "브라운", "2023-08-05", "15:40");
+
+        List<Reservation> reservations = RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200).extract()
+                .jsonPath().getList(".", Reservation.class);
+
+        Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+
+        Assertions.assertThat(reservations.size()).isEqualTo(count);
+    }
+
+    @Test
+    void 칠단계() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "2023-08-05");
+        params.put("time", "10:00");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(201)
+                .header("Location", "/reservations/1");
+
+        Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        Assertions.assertThat(count).isEqualTo(1);
+
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(204);
+
+        Integer countAfterDelete = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        Assertions.assertThat(countAfterDelete).isEqualTo(0);
     }
 }


### PR DESCRIPTION
- DB변경
기존 Repository에서 배열을 DB처럼 사용하던것에서, 관계형데이터베이스 H2를 이용하여 데이터의 저장과 접근을 이용함.

- 예약 생성
기존 Repository에서 생성된 예약엔터티를 반환했지만, 이번엔 생성된 예약 엔터티의 id만 반환.

- 예약 삭제
기존 Repository에서 예약 데이터를 삭제하면 반환하는것이 없었지만, 삭제된 데이터의 개수를 반환.

- 궁금한 점
예약 데이터를 생성할때, 저는 쿼리낭비를 최소한으로 하기위해 pk값만 반환하게 했습니다. 그런데 예약 데이터를 생성했을때 KeyHolder를 이용해서 생성된 id만 반환하는 방식과, id를 받고 id로부터 조회를 해서 엔터티를 반환하게 하는 방식중에 어떤것이 더 좋을지 고민됩니다.
