### PR TITLE
feat: 어드민 메인 페이지 구현, 예약 관리 페이지 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,11 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
 }
 
 test {

--- a/src/main/java/roomescape/Member.java
+++ b/src/main/java/roomescape/Member.java
@@ -1,0 +1,55 @@
+package roomescape;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+public class Member {
+    private Long id;
+    private String name;
+    private LocalDate date;
+    private LocalTime time;
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    public Member(Long id, String name, LocalDate date, LocalTime time) {
+    }
+
+    public Member(Long id, String name, String dateString, String timeString) {
+        this.id = id;
+        this.name = name;
+        this.date = LocalDate.parse(dateString, DATE_FORMATTER);
+        this.time = LocalTime.parse(timeString, TIME_FORMATTER);
+    }
+
+    public Member(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public LocalTime getTime() {return time; }
+
+    public static Member toEntity(Member member, Long id) {
+        return new Member(id, member.name, member.date, member.time);
+    }
+
+    public void update(Member newMember) {
+        this.name = newMember.name;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/roomescape/controller/BoardController.java
+++ b/src/main/java/roomescape/controller/BoardController.java
@@ -1,0 +1,17 @@
+package roomescape.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import roomescape.Member;
+
+import java.util.List;
+
+@Controller
+public class BoardController {
+
+    @GetMapping("/")
+    public String home(){
+        return "home";
+    }
+}

--- a/src/main/java/roomescape/controller/MemberController.java
+++ b/src/main/java/roomescape/controller/MemberController.java
@@ -1,0 +1,54 @@
+package roomescape.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+import roomescape.Member;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Controller
+public class MemberController {
+
+    private List<Member> members = new ArrayList<>();
+    private AtomicLong index = new AtomicLong(1);
+
+    @PostMapping("/members")
+    public ResponseEntity<Void> create(@RequestBody Member member) {
+        Member newMember = Member.toEntity(member, index.getAndIncrement());
+        members.add(newMember);
+        return ResponseEntity.created(URI.create("/members/" + newMember.getId())).build();
+    }
+
+    @GetMapping("/members")
+    public ResponseEntity<List<Member>> read() {
+        return ResponseEntity.ok().body(members);
+    }
+
+    @PutMapping("/members/{id}")
+    public ResponseEntity<Void> update(@RequestBody Member newMember, @PathVariable Long id) {
+        Member member = members.stream()
+            .filter(it -> Objects.equals(it.getId(), id))
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        member.update(newMember);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/members/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        Member member = members.stream()
+            .filter(it -> Objects.equals(it.getId(), id))
+            .findFirst()
+            .orElseThrow(RuntimeException::new);
+
+        members.remove(member);
+
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -1,0 +1,41 @@
+package roomescape.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+import roomescape.Member;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Controller
+public class ReservationController {
+    private List<Member> reservations = new ArrayList<>();
+    private AtomicLong idCounter = new AtomicLong(1);
+
+    public ReservationController() {
+        reservations.add(new Member(1L, "Brown", "2024-01-01", "10:00"));
+        reservations.add(new Member(2L, "Brown", "2024-02-02", "12:00"));
+        reservations.add(new Member(3L, "Brown", "2024-03-03", "15:00"));
+    }
+
+    @GetMapping("/reservation")
+    public String Reservation(Model model) {
+        model.addAttribute("reservations", reservations);
+        return "reservation";
+    }
+
+    @GetMapping("/reservations")
+    @ResponseBody
+    public List<Member> getMember() {
+        return reservations;
+    }
+
+}
+

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>index</title>
+</head>
+<body>
+인덱스 페이지 입니다.
+</body>
+</html>

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -1,9 +1,18 @@
 package roomescape;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -16,4 +25,19 @@ public class MissionStepTest {
                 .then().log().all()
                 .statusCode(200);
     }
+
+    @Test
+    void 이단계() {
+        RestAssured.given().log().all()
+                .when().get("/reservation")
+                .then().log().all()
+                .statusCode(200);
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(3)); // 아직 생성 요청이 없으니 Controller에서 임의로 넣어준 Reservation 갯수 만큼 검증하거나 0개임을 확인하세요.
+    }
+
 }


### PR DESCRIPTION
localhost:8080에서 어드민 메인 페이지를 응답하도록 기능을 추가했습니다.
`templates/home.html` 파일을 사용하여 메인 페이지 레이아웃을 구성했습니다. `/reservation`에서 예약 관리 페이지를 사용할 수 있도록 구현했습니다.
`templates/reservation.html` 파일을 사용하여 페이지 레이아웃을 설정했습니다. 페이지 로드 시 예약 목록을 조회하는 API도 함께 추가했습니다.

관련 이슈: 2단계까지 밖에 구현을 못했습니다..