### PR TITLE
[Spring MVC] 김두현 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
 }

--- a/src/main/java/roomescape/RoomescapeApplication.java
+++ b/src/main/java/roomescape/RoomescapeApplication.java
@@ -5,8 +5,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class RoomescapeApplication {
+
     public static void main(String[] args) {
         SpringApplication.run(RoomescapeApplication.class, args);
     }
-
 }

--- a/src/main/java/roomescape/controller/AdminViewController.java
+++ b/src/main/java/roomescape/controller/AdminViewController.java
@@ -1,0 +1,13 @@
+package roomescape.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AdminViewController {
+    @GetMapping(value = "/")
+    public String home() {
+        return "home";
+    }
+
+}

--- a/src/main/java/roomescape/controller/AdminViewController.java
+++ b/src/main/java/roomescape/controller/AdminViewController.java
@@ -10,4 +10,9 @@ public class AdminViewController {
         return "home";
     }
 
+    @GetMapping(value = "/reservation")
+    public String reservation() {
+        return "reservation";
+    }
+
 }

--- a/src/main/java/roomescape/controller/AdminViewController.java
+++ b/src/main/java/roomescape/controller/AdminViewController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class AdminViewController {
+
     @GetMapping(value = "/")
     public String home() {
         return "home";
@@ -14,5 +15,4 @@ public class AdminViewController {
     public String reservation() {
         return "reservation";
     }
-
 }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -29,8 +29,11 @@ public class ReservationController {
     }
 
     @GetMapping
-    public ResponseEntity<List<Reservation>> getReservations() {
-        return ResponseEntity.ok().body(reservations);
+    public ResponseEntity<List<ReservationResponseDto>> getReservations() {
+        List<ReservationResponseDto> result = reservations.stream()
+                .map(ReservationResponseDto::new)
+                .toList();
+        return ResponseEntity.ok().body(result);
     }
 
     @PostMapping

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -3,7 +3,6 @@ package roomescape.controller;
 import jakarta.annotation.PostConstruct;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequestDto;
@@ -17,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
-@Controller
+@RestController
 @RequestMapping("/reservations")
 public class ReservationController {
     private List<Reservation> reservations = new ArrayList<>();

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Controller
+@RequestMapping("/reservations")
 public class ReservationController {
     private List<Reservation> reservations = new ArrayList<>();
     private AtomicLong index = new AtomicLong(0);
@@ -28,19 +29,19 @@ public class ReservationController {
         reservations.add(new Reservation(index.incrementAndGet(), "브라운", "2023-01-02", "11:00"));
     }
 
-    @GetMapping("/reservations")
+    @GetMapping
     public ResponseEntity<List<Reservation>> getReservations() {
         return ResponseEntity.ok().body(reservations);
     }
 
-    @PostMapping("/reservations")
+    @PostMapping
     public ResponseEntity<ReservationResponseDto> addReservation(@RequestBody ReservationRequestDto requestDto) {
         Reservation newReservation = requestDto.toEntity(index.incrementAndGet());
         reservations.add(newReservation);
         return ResponseEntity.created(URI.create("/reservations/" + newReservation.getId())).body(new ReservationResponseDto(newReservation));
     }
 
-    @DeleteMapping("/reservations/{id}")
+    @DeleteMapping("/{id}")
     public ResponseEntity<Void> removeReservation(@PathVariable Long id) {
         Reservation findReservation = reservations.stream()
                 .filter(iter -> Objects.equals(iter.getId(), id))

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -31,7 +31,7 @@ public class ReservationController {
     @GetMapping
     public ResponseEntity<List<ReservationResponseDto>> getReservations() {
         List<ReservationResponseDto> result = reservations.stream()
-                .map(ReservationResponseDto::new)
+                .map(ReservationResponseDto::from)
                 .toList();
         return ResponseEntity.ok().body(result);
     }
@@ -40,7 +40,7 @@ public class ReservationController {
     public ResponseEntity<ReservationResponseDto> addReservation(@RequestBody ReservationRequestDto requestDto) {
         Reservation newReservation = requestDto.toEntity(index.incrementAndGet());
         reservations.add(newReservation);
-        return ResponseEntity.created(URI.create("/reservations/" + newReservation.getId())).body(new ReservationResponseDto(newReservation));
+        return ResponseEntity.created(URI.create("/reservations/" + newReservation.getId())).body(ReservationResponseDto.from(newReservation));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -54,15 +54,4 @@ public class ReservationController {
 
         return ResponseEntity.noContent().build();
     }
-
-    @ExceptionHandler(ReservationNotFoundException.class)
-    public ResponseEntity<Void> handleReservationNotFound(ReservationNotFoundException e) {
-        return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
-    }
-
-    @ExceptionHandler(RequestMissingArgumentException.class)
-    public ResponseEntity<Void> handleRequestMissingArgument(RequestMissingArgumentException e) {
-        return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
-    }
-
 }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -1,16 +1,17 @@
 package roomescape.controller;
 
 import jakarta.annotation.PostConstruct;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequestDto;
 import roomescape.dto.ReservationResponseDto;
+import roomescape.exception.RequestMissingArgumentException;
+import roomescape.exception.ReservationNotFoundException;
 
 import java.net.URI;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -44,11 +45,21 @@ public class ReservationController {
         Reservation findReservation = reservations.stream()
                 .filter(iter -> Objects.equals(iter.getId(), id))
                 .findFirst()
-                .orElseThrow(RuntimeException::new);
+                .orElseThrow(ReservationNotFoundException::new);
 
         reservations.remove(findReservation);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @ExceptionHandler(ReservationNotFoundException.class)
+    public ResponseEntity<Void> handleReservationNotFound(ReservationNotFoundException e) {
+        return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
+    }
+
+    @ExceptionHandler(RequestMissingArgumentException.class)
+    public ResponseEntity<Void> handleRequestMissingArgument(RequestMissingArgumentException e) {
+        return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
     }
 
 }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -1,0 +1,30 @@
+package roomescape.controller;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import roomescape.domain.Reservation;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Controller
+public class ReservationController {
+    private List<Reservation> reservations = new ArrayList<>();
+    private AtomicLong index = new AtomicLong(0);
+
+    @PostConstruct
+    public void initData() {
+        reservations.add(new Reservation(index.incrementAndGet(), "브라운", LocalDate.of(2023, 1, 1), LocalTime.of(10, 0)));
+        reservations.add(new Reservation(index.incrementAndGet(), "브라운", LocalDate.of(2023, 1, 2), LocalTime.of(11, 0)));
+    }
+
+    @GetMapping("/reservations")
+    public ResponseEntity<List<Reservation>> getReservations() {
+        return ResponseEntity.ok().body(reservations);
+    }
+}

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -15,11 +15,11 @@ public class Reservation {
     public Reservation() {
     }
 
-    public Reservation(Long id, String name, LocalDate date, LocalTime time) {
+    public Reservation(Long id, String name, String date, String time) {
         this.id = id;
         this.name = name;
-        this.date = date;
-        this.time = time;
+        this.date = LocalDate.parse(date);
+        this.time = LocalTime.parse(time);
     }
 
     public Long getId() {

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -1,0 +1,40 @@
+package roomescape.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class Reservation {
+    private Long id;
+    private String name;
+    private LocalDate date;
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime time;
+
+    public Reservation() {
+    }
+
+    public Reservation(Long id, String name, LocalDate date, LocalTime time) {
+        this.id = id;
+        this.name = name;
+        this.date = date;
+        this.time = time;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public LocalTime getTime() {
+        return time;
+    }
+}

--- a/src/main/java/roomescape/dto/ReservationRequestDto.java
+++ b/src/main/java/roomescape/dto/ReservationRequestDto.java
@@ -1,6 +1,7 @@
 package roomescape.dto;
 
 import roomescape.domain.Reservation;
+import roomescape.exception.RequestMissingArgumentException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -32,6 +33,10 @@ public class ReservationRequestDto {
     }
 
     public Reservation toEntity(Long id) {
+        if(this.name == null || this.name.trim().isEmpty() || this.date == null || this.time == null) {
+            throw new RequestMissingArgumentException();
+        }
+
         return new Reservation(id, this.name, this.date.toString(), this.time.toString());
     }
 }

--- a/src/main/java/roomescape/dto/ReservationRequestDto.java
+++ b/src/main/java/roomescape/dto/ReservationRequestDto.java
@@ -5,38 +5,20 @@ import roomescape.exception.RequestMissingArgumentException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Objects;
 
-public class ReservationRequestDto {
-    private LocalDate date;
-    private String name;
-    private LocalTime time;
-
-    public LocalDate getDate() {
-        return date;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public LocalTime getTime() {
-        return time;
-    }
-
-    public ReservationRequestDto() {
-    }
-
-    public ReservationRequestDto(LocalDate date, String name, LocalTime time) {
-        this.date = date;
-        this.name = name;
-        this.time = time;
+public record ReservationRequestDto (LocalDate date, String name, LocalTime time) {
+    // compact 생성자에서 데이터 검증
+    public ReservationRequestDto {
+        Objects.requireNonNull(date);
+        Objects.requireNonNull(name);
+        if (name.trim().isEmpty()) {
+            throw new RequestMissingArgumentException();
+        }
+        Objects.requireNonNull(time);
     }
 
     public Reservation toEntity(Long id) {
-        if(this.name == null || this.name.trim().isEmpty() || this.date == null || this.time == null) {
-            throw new RequestMissingArgumentException();
-        }
-
         return new Reservation(id, this.name, this.date.toString(), this.time.toString());
     }
 }

--- a/src/main/java/roomescape/dto/ReservationRequestDto.java
+++ b/src/main/java/roomescape/dto/ReservationRequestDto.java
@@ -7,7 +7,11 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Objects;
 
-public record ReservationRequestDto (LocalDate date, String name, LocalTime time) {
+public record ReservationRequestDto (
+        LocalDate date,
+        String name,
+        LocalTime time
+) {
     // compact 생성자에서 데이터 검증
     public ReservationRequestDto {
         Objects.requireNonNull(date);
@@ -19,6 +23,11 @@ public record ReservationRequestDto (LocalDate date, String name, LocalTime time
     }
 
     public Reservation toEntity(Long id) {
-        return new Reservation(id, this.name, this.date.toString(), this.time.toString());
+        return new Reservation(
+                id,
+                this.name,
+                this.date.toString(),
+                this.time.toString()
+        );
     }
 }

--- a/src/main/java/roomescape/dto/ReservationRequestDto.java
+++ b/src/main/java/roomescape/dto/ReservationRequestDto.java
@@ -1,0 +1,37 @@
+package roomescape.dto;
+
+import roomescape.domain.Reservation;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class ReservationRequestDto {
+    private LocalDate date;
+    private String name;
+    private LocalTime time;
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public LocalTime getTime() {
+        return time;
+    }
+
+    public ReservationRequestDto() {
+    }
+
+    public ReservationRequestDto(LocalDate date, String name, LocalTime time) {
+        this.date = date;
+        this.name = name;
+        this.time = time;
+    }
+
+    public Reservation toEntity(Long id) {
+        return new Reservation(id, this.name, this.date.toString(), this.time.toString());
+    }
+}

--- a/src/main/java/roomescape/dto/ReservationResponseDto.java
+++ b/src/main/java/roomescape/dto/ReservationResponseDto.java
@@ -6,34 +6,20 @@ import roomescape.domain.Reservation;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-public class ReservationResponseDto {
-    private final Long id;
-    private final String name;
-    private final LocalDate date;
+public record ReservationResponseDto(
+        Long id,
+        String name,
+        LocalDate date,
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime time
+) {
 
-    @JsonFormat(pattern = "HH:mm")
-    private final LocalTime time;
-
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public LocalDate getDate() {
-        return date;
-    }
-
-    public LocalTime getTime() {
-        return time;
-    }
-
-    public ReservationResponseDto(Reservation entity) {
-        this.id = entity.getId();
-        this.name = entity.getName();
-        this.date = entity.getDate();
-        this.time = entity.getTime();
+    public static ReservationResponseDto from(Reservation entity) {
+        return new ReservationResponseDto(
+                entity.getId(),
+                entity.getName(),
+                entity.getDate(),
+                entity.getTime()
+        );
     }
 }

--- a/src/main/java/roomescape/dto/ReservationResponseDto.java
+++ b/src/main/java/roomescape/dto/ReservationResponseDto.java
@@ -16,10 +16,10 @@ public record ReservationResponseDto(
 
     public static ReservationResponseDto from(Reservation entity) {
         return new ReservationResponseDto(
-                entity.getId(),
-                entity.getName(),
-                entity.getDate(),
-                entity.getTime()
+            entity.getId(),
+            entity.getName(),
+            entity.getDate(),
+            entity.getTime()
         );
     }
 }

--- a/src/main/java/roomescape/dto/ReservationResponseDto.java
+++ b/src/main/java/roomescape/dto/ReservationResponseDto.java
@@ -1,0 +1,39 @@
+package roomescape.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import roomescape.domain.Reservation;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class ReservationResponseDto {
+    private final Long id;
+    private final String name;
+    private final LocalDate date;
+
+    @JsonFormat(pattern = "HH:mm")
+    private final LocalTime time;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public LocalTime getTime() {
+        return time;
+    }
+
+    public ReservationResponseDto(Reservation entity) {
+        this.id = entity.getId();
+        this.name = entity.getName();
+        this.date = entity.getDate();
+        this.time = entity.getTime();
+    }
+}

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -13,22 +13,22 @@ import java.util.Map;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ReservationNotFoundException.class)
-    public ResponseEntity<Void> handleReservationNotFound(ReservationNotFoundException e) {
+    protected final ResponseEntity<Void> handleReservationNotFound(ReservationNotFoundException e) {
         return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
     }
 
     @ExceptionHandler(RequestMissingArgumentException.class)
-    public ResponseEntity<Void> handleRequestMissingArgument(RequestMissingArgumentException e) {
+    protected final ResponseEntity<Void> handleRequestMissingArgument(RequestMissingArgumentException e) {
         return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
     }
 
     @ExceptionHandler(NullPointerException.class)
-    public ResponseEntity<String> handleNullPointerException(NullPointerException ex) {
+    protected final ResponseEntity<String> handleNullPointerException(NullPointerException ex) {
         return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
     }
 
     @ExceptionHandler(DateTimeParseException.class)
-    public ResponseEntity<Map<String, String>> handleDateTimeParseException(DateTimeParseException ex) {
+    protected final ResponseEntity<Map<String, String>> handleDateTimeParseException(DateTimeParseException ex) {
         Map<String, String> response = new HashMap<>();
         response.put("message", ex.getMessage());
         return ResponseEntity.status(HttpStatusCode.valueOf(400)).body(response);

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
     @ExceptionHandler(ReservationNotFoundException.class)
     public ResponseEntity<Void> handleReservationNotFound(ReservationNotFoundException e) {
         return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -5,6 +5,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.Map;
+
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -21,5 +25,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(NullPointerException.class)
     public ResponseEntity<String> handleNullPointerException(NullPointerException ex) {
         return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
+    }
+
+    @ExceptionHandler(DateTimeParseException.class)
+    public ResponseEntity<Map<String, String>> handleDateTimeParseException(DateTimeParseException ex) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatusCode.valueOf(400)).body(response);
     }
 }

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -16,4 +16,9 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Void> handleRequestMissingArgument(RequestMissingArgumentException e) {
         return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
     }
+
+    @ExceptionHandler(NullPointerException.class)
+    public ResponseEntity<String> handleNullPointerException(NullPointerException ex) {
+        return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
+    }
 }

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package roomescape.exception;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(ReservationNotFoundException.class)
+    public ResponseEntity<Void> handleReservationNotFound(ReservationNotFoundException e) {
+        return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
+    }
+
+    @ExceptionHandler(RequestMissingArgumentException.class)
+    public ResponseEntity<Void> handleRequestMissingArgument(RequestMissingArgumentException e) {
+        return ResponseEntity.status(HttpStatusCode.valueOf(400)).build();
+    }
+}

--- a/src/main/java/roomescape/exception/RequestMissingArgumentException.java
+++ b/src/main/java/roomescape/exception/RequestMissingArgumentException.java
@@ -1,0 +1,11 @@
+package roomescape.exception;
+
+public class RequestMissingArgumentException extends RuntimeException{
+    public RequestMissingArgumentException() {
+        super();
+    }
+
+    public RequestMissingArgumentException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/exception/ReservationNotFoundException.java
+++ b/src/main/java/roomescape/exception/ReservationNotFoundException.java
@@ -1,0 +1,11 @@
+package roomescape.exception;
+
+public class ReservationNotFoundException extends RuntimeException{
+    public ReservationNotFoundException() {
+        super();
+    }
+
+    public ReservationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import static org.hamcrest.Matchers.is;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -15,5 +16,19 @@ public class MissionStepTest {
                 .when().get("/")
                 .then().log().all()
                 .statusCode(200);
+    }
+
+    @Test
+    void 이단계() {
+        RestAssured.given().log().all()
+                .when().get("/reservation")
+                .then().log().all()
+                .statusCode(200);
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("reservations.size()", is(2)); // 아직 생성 요청이 없으니 Controller에서 임의로 넣어준 Reservation 갯수 만큼 검증하거나 0개임을 확인하세요.
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -91,5 +92,21 @@ public class MissionStepTest {
                 .when().delete("/reservations/4")
                 .then().log().all()
                 .statusCode(400);
+    }
+
+    @Test
+    void 형식에_맞지_않는_값_제공() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "hahahaha");
+        params.put("time", "15:40");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(400) // 400 Bad Request 응답 확인
+                .body("message", equalTo("Text 'hahahaha' could not be parsed at index 0"));
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -70,4 +70,26 @@ public class MissionStepTest {
                 .statusCode(200)
                 .body("size()", is(2));
     }
+
+    @Test
+    void 사단계() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "");
+        params.put("time", "");
+
+        // 필요한 인자가 없는 경우
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(400);
+
+        // 삭제할 예약이 없는 경우
+        RestAssured.given().log().all()
+                .when().delete("/reservations/4")
+                .then().log().all()
+                .statusCode(400);
+    }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -1,9 +1,14 @@
 package roomescape;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.Matchers.is;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -30,5 +35,39 @@ public class MissionStepTest {
                 .then().log().all()
                 .statusCode(200)
                 .body("reservations.size()", is(2)); // 아직 생성 요청이 없으니 Controller에서 임의로 넣어준 Reservation 갯수 만큼 검증하거나 0개임을 확인하세요.
+    }
+
+    @Test
+    void 삼단계() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "2023-08-05");
+        params.put("time", "15:40");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(201)
+                .header("Location", "/reservations/3")
+                .body("id", is(3));
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(3));
+
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(204);
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(2));
     }
 }


### PR DESCRIPTION
### 1단계 : 홈 화면 구현
* 요구사항 구현에 필요한 spring-boot-starter-web과 spring-boot-starter-thymeleaf 의존성을 추가하였습니다.

### 2단계 : 예약 조회
* 요구사항에 따라 컨트롤러 코드를 2개로 분리했습니다. AdminViewController는 사용자 인터페이스와 관련된 뷰를 렌더링하는 역할을 담당하며, ReservationController는 API 요청에 대한 처리를 담당합니다.
* 예약 API 명세를 참고하여 Reservation 객체를 작성했습니다.
* ReservationController가 초기화될 때 reservations에 임시 데이터를 추가할 수 있도록 `@PostConstruct` 를 이용했습니다. 이에 맞춰서 테스트 코드의 조건을 수정했습니다.
* `@JsonFormat(pattern = "HH:mm")` 을 사용하여 `time`이 요구사항과 동일한 형식으로 출력되도록 하였습니다. 

### 3단계 : 예약 추가 / 취소
* 도메인 객체인 Reservation과 컨트롤러 계층을 분리하기 위해서 DTO 객체 2가지를 추가했습니다. `ReservationRequestDto` 는 클라이언트로부터 새로운 예약 정보를 받아오는 역할을 담당하고, `ReservationResponseDto`는 예약 처리 결과를 출력하는 역할을 담당합니다. 
* 예약 취소 메서드에서 id에 맞는 예약 객체를 찾는 코드를 초록 스터디의 학습 테스트 코드를 참고하여 stream으로 처리했습니다.

### 4단계 : 예외 처리
* 새로운 예외 처리 클래스를 추가했습니다. 예외로 제시된 두 경우 모두 실행 중 일어나는 예외이기 때문에 `RuntimeException`을 상속받아서 작성했습니다.
* 조건에 제시된 힌트 `@ExceptionHandler`을 참고해서 예외를 처리하는 메서드를 작성했습니다.
* 이름 인자값에 공백이 포함되는 경우를 처리하기 위해 `trim().isEmpty()`를 사용했습니다.

### 알아봐야할 점
* 현재 코드에선 컨트롤러 계층에 예외처리 메서드가 포함되어 있는데, 처리해야할 예외의 수가 늘어난다면 이를 분리해야 하는 것이 맞는지, 분리한다면 어떤 위치에 생성해야 하는지.
* 현재 코드의 `ReservationRequestDto`에서 곧바로 도메인 객체를 반환하는 `toEntity()` 메서드를 작성했는데, 이 때문에 DTO가 도메인 객체에 의존하고 있다. 따로 서비스 계층을 두지 않고 DTO에서 인자값 까지 검증해서 코드도 깔끔하고 편리하긴 한데 이 방식의 구체적인 문제점.