### PR TITLE
[Spring JDBC] 임지현 미션 제출합니다2.

### DIFF
--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -18,7 +18,7 @@ public class Reservation {
 
     private Long id;
 
-    private String customerName;
+    private String name;
 
     private LocalDate date;
 
@@ -27,17 +27,17 @@ public class Reservation {
     protected Reservation() {
     }
 
-    public Reservation(final Long id, final String customerName, final LocalDate date, final LocalTime time) {
-        validate(customerName, date, time);
+    public Reservation(final Long id, final String name, final LocalDate date, final LocalTime time) {
+        validate(name, date, time);
         this.id = id;
-        this.customerName = customerName;
+        this.name = name;
         this.date = date;
         this.time = time;
     }
 
-    public Reservation(final String customerName, final LocalDate date, final LocalTime time) {
-        validate(customerName, date, time);
-        this.customerName = customerName;
+    public Reservation(final String name, final LocalDate date, final LocalTime time) {
+        validate(name, date, time);
+        this.name = name;
         this.date = date;
         this.time = time;
     }
@@ -46,8 +46,8 @@ public class Reservation {
         return id;
     }
 
-    public String getCustomerName() {
-        return customerName;
+    public String getName() {
+        return name;
     }
 
     public LocalDate getDate() {
@@ -58,13 +58,13 @@ public class Reservation {
         return time;
     }
 
-    private void validate(final String customerName, final LocalDate date, final LocalTime time) {
-        validateCustomerName(customerName);
+    private void validate(final String name, final LocalDate date, final LocalTime time) {
+        validateName(name);
         validateDate(date);
         validateTime(time);
     }
 
-    private void validateCustomerName(final String customerName) {
+    private void validateName(final String customerName) {
         validateNameExists(customerName);
         validateNameLength(customerName);
         validateNameFormat(customerName);

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -45,7 +45,7 @@ public class Reservation {
         this.time = time;
     }
 
-    public boolean isExpired(Clock clock) {
+    public boolean isExpired(final Clock clock) {
         LocalDateTime dateTime = date.atTime(time);
         return dateTime.isBefore(LocalDateTime.now(clock));
     }

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -18,7 +18,7 @@ public class Reservation {
 
     private Long id;
 
-    private String name;
+    private String customerName;
 
     private LocalDate date;
 
@@ -27,17 +27,17 @@ public class Reservation {
     protected Reservation() {
     }
 
-    public Reservation(final Long id, final String name, final LocalDate date, final LocalTime time) {
-        validate(name, date, time);
+    public Reservation(final Long id, final String customerName, final LocalDate date, final LocalTime time) {
+        validate(customerName, date, time);
         this.id = id;
-        this.name = name;
+        this.customerName = customerName;
         this.date = date;
         this.time = time;
     }
 
-    public Reservation(final String name, final LocalDate date, final LocalTime time) {
-        validate(name, date, time);
-        this.name = name;
+    public Reservation(final String customerName, final LocalDate date, final LocalTime time) {
+        validate(customerName, date, time);
+        this.customerName = customerName;
         this.date = date;
         this.time = time;
     }
@@ -46,8 +46,8 @@ public class Reservation {
         return id;
     }
 
-    public String getName() {
-        return name;
+    public String getCustomerName() {
+        return customerName;
     }
 
     public LocalDate getDate() {
@@ -58,32 +58,32 @@ public class Reservation {
         return time;
     }
 
-    private void validate(final String name, final LocalDate date, final LocalTime time) {
-        validateName(name);
+    private void validate(final String customerName, final LocalDate date, final LocalTime time) {
+        validateCustomerName(customerName);
         validateDate(date);
         validateTime(time);
     }
 
-    private void validateName(final String name) {
-        validateNameExists(name);
-        validateNameLength(name);
-        validateNameFormat(name);
+    private void validateCustomerName(final String customerName) {
+        validateNameExists(customerName);
+        validateNameLength(customerName);
+        validateNameFormat(customerName);
     }
 
-    private void validateNameExists(final String name) {
-        if (name == null || name.isBlank()) {
+    private void validateNameExists(final String customerName) {
+        if (customerName == null || customerName.isBlank()) {
             throw new BadRequestException(INVALID_NAME.getMessage());
         }
     }
 
-    private void validateNameLength(final String name) {
-        if (name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH) {
+    private void validateNameLength(final String customerName) {
+        if (customerName.length() < MIN_NAME_LENGTH || customerName.length() > MAX_NAME_LENGTH) {
             throw new BadRequestException(INVALID_NAME.getMessage());
         }
     }
 
-    private void validateNameFormat(final String name) {
-        if (!NAME_FORMAT.matcher(name).find()) {
+    private void validateNameFormat(final String customerName) {
+        if (!NAME_FORMAT.matcher(customerName).find()) {
             throw new BadRequestException(INVALID_NAME.getMessage());
         }
     }

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -2,7 +2,9 @@ package roomescape.domain;
 
 import roomescape.global.exception.BadRequestException;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.regex.Pattern;
 
@@ -15,6 +17,7 @@ public class Reservation {
     private static final int MIN_NAME_LENGTH = 2;
     private static final int MAX_NAME_LENGTH = 10;
     private static final Pattern NAME_FORMAT = Pattern.compile("^[가-힣]+$");
+    private static final int OCLOCK = 0;
 
     private Long id;
 
@@ -40,6 +43,11 @@ public class Reservation {
         this.name = name;
         this.date = date;
         this.time = time;
+    }
+
+    public boolean isExpired(Clock clock) {
+        LocalDateTime dateTime = date.atTime(time);
+        return dateTime.isBefore(LocalDateTime.now(clock));
     }
 
     public Long getId() {
@@ -106,7 +114,7 @@ public class Reservation {
     }
 
     private void validateTimeOnTheHour(final LocalTime time) {
-        if (time.getMinute() != 0) {
+        if (time.getMinute() != OCLOCK) {
             throw new BadRequestException(INVALID_TIME.getMessage());
         }
     }

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -1,4 +1,4 @@
-package roomescape.entity;
+package roomescape.domain;
 
 import roomescape.global.exception.BadRequestException;
 

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -88,15 +88,26 @@ public class Reservation {
         }
     }
 
+    private void validateDate(final LocalDate date) {
+        if (date == null) {
+            throw new BadRequestException(INVALID_DATE.getMessage());
+        }
+    }
+
     private void validateTime(final LocalTime time) {
+        validateTimeExists(time);
+        validateTimeOnTheHour(time);
+    }
+
+    private void validateTimeExists(final LocalTime time) {
         if (time == null) {
             throw new BadRequestException(INVALID_TIME.getMessage());
         }
     }
 
-    private void validateDate(final LocalDate date) {
-        if (date == null) {
-            throw new BadRequestException(INVALID_DATE.getMessage());
+    private void validateTimeOnTheHour(final LocalTime time) {
+        if (time.getMinute() != 0) {
+            throw new BadRequestException(INVALID_TIME.getMessage());
         }
     }
 }

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -17,7 +17,7 @@ public class Reservation {
     private static final int MIN_NAME_LENGTH = 2;
     private static final int MAX_NAME_LENGTH = 10;
     private static final Pattern NAME_FORMAT = Pattern.compile("^[가-힣]+$");
-    private static final int OCLOCK = 0;
+    private static final int VALID_MINUTE_UNIT = 0;
 
     private Long id;
 
@@ -104,7 +104,7 @@ public class Reservation {
 
     private void validateTime(final LocalTime time) {
         validateTimeExists(time);
-        validateTimeOnTheHour(time);
+        validateTimeFormat(time);
     }
 
     private void validateTimeExists(final LocalTime time) {
@@ -113,8 +113,8 @@ public class Reservation {
         }
     }
 
-    private void validateTimeOnTheHour(final LocalTime time) {
-        if (time.getMinute() != OCLOCK) {
+    private void validateTimeFormat(final LocalTime time) {
+        if (time.getMinute() != VALID_MINUTE_UNIT) {
             throw new BadRequestException(INVALID_TIME.getMessage());
         }
     }

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -72,26 +72,26 @@ public class Reservation {
         validateTime(time);
     }
 
-    private void validateName(final String customerName) {
-        validateNameExists(customerName);
-        validateNameLength(customerName);
-        validateNameFormat(customerName);
+    private void validateName(final String name) {
+        validateNameExists(name);
+        validateNameLength(name);
+        validateNameFormat(name);
     }
 
-    private void validateNameExists(final String customerName) {
-        if (customerName == null || customerName.isBlank()) {
+    private void validateNameExists(final String name) {
+        if (name == null || name.isBlank()) {
             throw new BadRequestException(INVALID_NAME.getMessage());
         }
     }
 
-    private void validateNameLength(final String customerName) {
-        if (customerName.length() < MIN_NAME_LENGTH || customerName.length() > MAX_NAME_LENGTH) {
+    private void validateNameLength(final String name) {
+        if (name.length() < MIN_NAME_LENGTH || name.length() > MAX_NAME_LENGTH) {
             throw new BadRequestException(INVALID_NAME.getMessage());
         }
     }
 
-    private void validateNameFormat(final String customerName) {
-        if (!NAME_FORMAT.matcher(customerName).find()) {
+    private void validateNameFormat(final String name) {
+        if (!NAME_FORMAT.matcher(name).find()) {
             throw new BadRequestException(INVALID_NAME.getMessage());
         }
     }

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -4,7 +4,6 @@ import roomescape.global.exception.BadRequestException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
 import static roomescape.global.exception.ExceptionMessage.INVALID_DATE;
@@ -13,7 +12,6 @@ import static roomescape.global.exception.ExceptionMessage.INVALID_TIME;
 
 public class Reservation {
 
-    public static final AtomicLong RESERVATION_ID = new AtomicLong(0);
     private static final int MIN_NAME_LENGTH = 2;
     private static final int MAX_NAME_LENGTH = 10;
     private static final Pattern NAME_FORMAT = Pattern.compile("^[가-힣]+$");
@@ -37,16 +35,11 @@ public class Reservation {
         this.time = time;
     }
 
-    public Reservation(String name, LocalDate date, LocalTime time) {
+    public Reservation(final String name, final LocalDate date, final LocalTime time) {
         validate(name, date, time);
-        this.id = RESERVATION_ID.incrementAndGet();
         this.name = name;
         this.date = date;
         this.time = time;
-    }
-
-    public boolean isSameId(final long reservationId) {
-        return id.equals(reservationId);
     }
 
     public Long getId() {

--- a/src/main/java/roomescape/dto/request/CreateReservationRequest.java
+++ b/src/main/java/roomescape/dto/request/CreateReservationRequest.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record CreateReservationRequest(
-        String customerName,
+        String name,
 
         LocalDate date,
 
@@ -14,7 +14,7 @@ public record CreateReservationRequest(
 ) {
     public Reservation toReservation() {
         return new Reservation(
-                customerName,
+                name,
                 date,
                 time
         );

--- a/src/main/java/roomescape/dto/request/CreateReservationRequest.java
+++ b/src/main/java/roomescape/dto/request/CreateReservationRequest.java
@@ -1,5 +1,7 @@
 package roomescape.dto.request;
 
+import roomescape.entity.Reservation;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 
@@ -10,4 +12,11 @@ public record CreateReservationRequest(
 
         LocalTime time
 ) {
+    public Reservation toReservation() {
+        return new Reservation(
+                name,
+                date,
+                time
+        );
+    }
 }

--- a/src/main/java/roomescape/dto/request/CreateReservationRequest.java
+++ b/src/main/java/roomescape/dto/request/CreateReservationRequest.java
@@ -1,6 +1,6 @@
 package roomescape.dto.request;
 
-import roomescape.entity.Reservation;
+import roomescape.domain.Reservation;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/src/main/java/roomescape/dto/request/CreateReservationRequest.java
+++ b/src/main/java/roomescape/dto/request/CreateReservationRequest.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record CreateReservationRequest(
-        String name,
+        String customerName,
 
         LocalDate date,
 
@@ -14,7 +14,7 @@ public record CreateReservationRequest(
 ) {
     public Reservation toReservation() {
         return new Reservation(
-                name,
+                customerName,
                 date,
                 time
         );

--- a/src/main/java/roomescape/dto/response/ReservationResponse.java
+++ b/src/main/java/roomescape/dto/response/ReservationResponse.java
@@ -1,6 +1,6 @@
 package roomescape.dto.response;
 
-import roomescape.entity.Reservation;
+import roomescape.domain.Reservation;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/src/main/java/roomescape/dto/response/ReservationResponse.java
+++ b/src/main/java/roomescape/dto/response/ReservationResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalTime;
 public record ReservationResponse(
         long id,
 
-        String customerName,
+        String name,
 
         LocalDate date,
 
@@ -16,7 +16,7 @@ public record ReservationResponse(
 ) {
     public ReservationResponse(Reservation reservation) {
         this(reservation.getId(),
-                reservation.getCustomerName(),
+                reservation.getName(),
                 reservation.getDate(),
                 reservation.getTime());
     }

--- a/src/main/java/roomescape/dto/response/ReservationResponse.java
+++ b/src/main/java/roomescape/dto/response/ReservationResponse.java
@@ -8,7 +8,7 @@ import java.time.LocalTime;
 public record ReservationResponse(
         long id,
 
-        String name,
+        String customerName,
 
         LocalDate date,
 
@@ -16,7 +16,7 @@ public record ReservationResponse(
 ) {
     public ReservationResponse(Reservation reservation) {
         this(reservation.getId(),
-                reservation.getName(),
+                reservation.getCustomerName(),
                 reservation.getDate(),
                 reservation.getTime());
     }

--- a/src/main/java/roomescape/global/config/TimeConfig.java
+++ b/src/main/java/roomescape/global/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package roomescape.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/roomescape/global/exception/ExceptionMessage.java
+++ b/src/main/java/roomescape/global/exception/ExceptionMessage.java
@@ -2,10 +2,13 @@ package roomescape.global.exception;
 
 public enum ExceptionMessage {
 
+    //Bad Request
     INVALID_NAME("잘못된 이름 양식입니다."),
     INVALID_DATE("잘못된 날짜 양식입니다."),
     INVALID_TIME("잘못된 시간 양식입니다."),
     INVALID_INPUT_FORMAT("잘못된 입력 양식입니다."),
+
+    // Not Found
     RESERVATION_NOT_EXISTS("존재하지 않는 예약 내역입니다."),
     ;
 

--- a/src/main/java/roomescape/global/exception/ExceptionMessage.java
+++ b/src/main/java/roomescape/global/exception/ExceptionMessage.java
@@ -9,7 +9,7 @@ public enum ExceptionMessage {
     INVALID_DATETIME("예약 가능 시간은 현재 이후여야 합니다."),
     INVALID_INPUT_FORMAT("잘못된 입력 양식입니다."),
     RESERVATION_NOT_EXISTS("존재하지 않는 예약 내역입니다."),
-    RESERVATION_ALREADY_EXISTS("존재하지 않는 예약 내역입니다."),
+    RESERVATION_ALREADY_EXISTS("해당 시간에 예약이 이미 존재합니다."),
     ;
 
     private static final String ERROR_PREFIX = "[ERROR] ";

--- a/src/main/java/roomescape/global/exception/ExceptionMessage.java
+++ b/src/main/java/roomescape/global/exception/ExceptionMessage.java
@@ -7,9 +7,8 @@ public enum ExceptionMessage {
     INVALID_DATE("잘못된 날짜 양식입니다."),
     INVALID_TIME("잘못된 시간 양식입니다."),
     INVALID_INPUT_FORMAT("잘못된 입력 양식입니다."),
-
-    // Not Found
     RESERVATION_NOT_EXISTS("존재하지 않는 예약 내역입니다."),
+    RESERVATION_ALREADY_EXISTS("존재하지 않는 예약 내역입니다."),
     ;
 
     private static final String ERROR_PREFIX = "[ERROR] ";

--- a/src/main/java/roomescape/global/exception/ExceptionMessage.java
+++ b/src/main/java/roomescape/global/exception/ExceptionMessage.java
@@ -6,6 +6,7 @@ public enum ExceptionMessage {
     INVALID_NAME("잘못된 이름 양식입니다."),
     INVALID_DATE("잘못된 날짜 양식입니다."),
     INVALID_TIME("잘못된 시간 양식입니다. 정각 단위로 입력해주세요."),
+    INVALID_DATETIME("예약 가능 시간은 현재 이후여야 합니다."),
     INVALID_INPUT_FORMAT("잘못된 입력 양식입니다."),
     RESERVATION_NOT_EXISTS("존재하지 않는 예약 내역입니다."),
     RESERVATION_ALREADY_EXISTS("존재하지 않는 예약 내역입니다."),

--- a/src/main/java/roomescape/global/exception/ExceptionMessage.java
+++ b/src/main/java/roomescape/global/exception/ExceptionMessage.java
@@ -5,7 +5,7 @@ public enum ExceptionMessage {
     //Bad Request
     INVALID_NAME("잘못된 이름 양식입니다."),
     INVALID_DATE("잘못된 날짜 양식입니다."),
-    INVALID_TIME("잘못된 시간 양식입니다."),
+    INVALID_TIME("잘못된 시간 양식입니다. 정각 단위로 입력해주세요."),
     INVALID_INPUT_FORMAT("잘못된 입력 양식입니다."),
     RESERVATION_NOT_EXISTS("존재하지 않는 예약 내역입니다."),
     RESERVATION_ALREADY_EXISTS("존재하지 않는 예약 내역입니다."),

--- a/src/main/java/roomescape/global/exception/NotFoundException.java
+++ b/src/main/java/roomescape/global/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package roomescape.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundException extends RoomScapeException {
+    public NotFoundException(final String errorMessage) {
+        super(HttpStatus.NOT_FOUND.value(), errorMessage);
+    }
+}

--- a/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
@@ -3,7 +3,7 @@ package roomescape.repository;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
-import roomescape.entity.Reservation;
+import roomescape.domain.Reservation;
 
 import java.util.List;
 

--- a/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
@@ -9,6 +9,8 @@ import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 import roomescape.domain.Reservation;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,6 +62,13 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
         } catch (EmptyResultDataAccessException emptyResultDataAccessException) {
             return Optional.empty();
         }
+    }
+
+    @Override
+    public boolean existsByDateAndTime(final LocalDate date, final LocalTime time) {
+        String selectByDateAndTime = "SELECT * FROM RESERVATION" +
+                "WHERE EXISTS(SELECT * FROM RESERVATION WHERE `date` = ? AND `time` = ?)";
+        return jdbcTemplate.queryForObject(selectByDateAndTime, Boolean.class, date, time);
     }
 
     @Override

--- a/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
@@ -1,5 +1,6 @@
 package roomescape.repository;
 
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
@@ -7,11 +8,9 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 import roomescape.domain.Reservation;
-import roomescape.global.exception.BadRequestException;
 
 import java.util.List;
-
-import static roomescape.global.exception.ExceptionMessage.RESERVATION_NOT_EXISTS;
+import java.util.Optional;
 
 @Repository
 public class JdbcTemplateReservationRepository implements ReservationRepository {
@@ -38,7 +37,6 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
     @Override
     public Reservation save(final Reservation reservation) {
         SqlParameterSource parameters = new BeanPropertySqlParameterSource(reservation);
-
         long id = jdbcInsert.executeAndReturnKey(parameters).longValue();
         return new Reservation(
                 id,
@@ -54,14 +52,13 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
     }
 
     @Override
-    public Reservation findById(final long reservationId) {
-        Reservation reservation;
+    public Optional<Reservation> findById(final long reservationId) {
         try {
-            reservation = jdbcTemplate.queryForObject("SELECT * FROM RESERVATION WHERE id = ?", RESERVATION_ROW_MAPPER, reservationId);
-        } catch (RuntimeException runtimeException) {
-            throw new BadRequestException(RESERVATION_NOT_EXISTS.getMessage());
+            Reservation reservation = jdbcTemplate.queryForObject("SELECT * FROM RESERVATION WHERE id = ?", RESERVATION_ROW_MAPPER, reservationId);
+            return Optional.of(reservation);
+        } catch (EmptyResultDataAccessException emptyResultDataAccessException) {
+            return Optional.empty();
         }
-        return reservation;
     }
 
     @Override

--- a/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
@@ -2,14 +2,16 @@ package roomescape.repository;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 import roomescape.domain.Reservation;
+import roomescape.global.exception.BadRequestException;
 
 import java.util.List;
-import java.util.Optional;
+
+import static roomescape.global.exception.ExceptionMessage.RESERVATION_NOT_EXISTS;
 
 @Repository
 public class JdbcTemplateReservationRepository implements ReservationRepository {
@@ -20,8 +22,8 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
             new Reservation(
                     rs.getLong("id"),
                     rs.getString("customer_name"),
-                    rs.getDate("reservation_date").toLocalDate(),
-                    rs.getTime("reservation_time").toLocalTime()
+                    rs.getDate("date").toLocalDate(),
+                    rs.getTime("time").toLocalTime()
             );
 
     private final JdbcTemplate jdbcTemplate;
@@ -35,16 +37,12 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
 
     @Override
     public Reservation save(final Reservation reservation) {
-        SqlParameterSource parameters = new MapSqlParameterSource()
-                .addValue("id", reservation.getId())
-                .addValue("customer_name", reservation.getName())
-                .addValue("reservation_date", reservation.getDate())
-                .addValue("reservation_time", reservation.getTime());
+        SqlParameterSource parameters = new BeanPropertySqlParameterSource(reservation);
 
         long id = jdbcInsert.executeAndReturnKey(parameters).longValue();
         return new Reservation(
                 id,
-                reservation.getName(),
+                reservation.getCustomerName(),
                 reservation.getDate(),
                 reservation.getTime()
         );
@@ -56,8 +54,14 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
     }
 
     @Override
-    public Optional<Reservation> findById(final long reservationId) {
-        return Optional.of(jdbcTemplate.queryForObject("SELECT * FROM RESERVATION WHERE id = ?", RESERVATION_ROW_MAPPER, reservationId));
+    public Reservation findById(final long reservationId) {
+        Reservation reservation;
+        try {
+            reservation = jdbcTemplate.queryForObject("SELECT * FROM RESERVATION WHERE id = ?", RESERVATION_ROW_MAPPER, reservationId);
+        } catch (RuntimeException runtimeException) {
+            throw new BadRequestException(RESERVATION_NOT_EXISTS.getMessage());
+        }
+        return reservation;
     }
 
     @Override

--- a/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
@@ -2,13 +2,19 @@ package roomescape.repository;
 
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 import roomescape.domain.Reservation;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public class JdbcTemplateReservationRepository implements ReservationRepository {
+
+    private final SimpleJdbcInsert jdbcInsert;
 
     private static final RowMapper<Reservation> RESERVATION_ROW_MAPPER = (rs, rowNum) ->
             new Reservation(
@@ -22,10 +28,40 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
 
     public JdbcTemplateReservationRepository(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
+        this.jdbcInsert = new SimpleJdbcInsert(jdbcTemplate)
+                .withTableName("RESERVATION")
+                .usingGeneratedKeyColumns("id");
+    }
+
+    @Override
+    public Reservation save(final Reservation reservation) {
+        SqlParameterSource parameters = new MapSqlParameterSource()
+                .addValue("id", reservation.getId())
+                .addValue("customer_name", reservation.getName())
+                .addValue("reservation_date", reservation.getDate())
+                .addValue("reservation_time", reservation.getTime());
+
+        long id = jdbcInsert.executeAndReturnKey(parameters).longValue();
+        return new Reservation(
+                id,
+                reservation.getName(),
+                reservation.getDate(),
+                reservation.getTime()
+        );
     }
 
     @Override
     public List<Reservation> findAll() {
         return jdbcTemplate.query("SELECT * FROM RESERVATION", RESERVATION_ROW_MAPPER);
+    }
+
+    @Override
+    public Optional<Reservation> findById(final long reservationId) {
+        return Optional.of(jdbcTemplate.queryForObject("SELECT * FROM RESERVATION WHERE id = ?", RESERVATION_ROW_MAPPER, reservationId));
+    }
+
+    @Override
+    public void deleteById(final long reservationId) {
+        jdbcTemplate.update("DELETE FROM reservation WHERE id = ?", reservationId);
     }
 }

--- a/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
@@ -15,8 +15,6 @@ import java.util.Optional;
 @Repository
 public class JdbcTemplateReservationRepository implements ReservationRepository {
 
-    private final SimpleJdbcInsert jdbcInsert;
-
     private static final RowMapper<Reservation> RESERVATION_ROW_MAPPER = (rs, rowNum) ->
             new Reservation(
                     rs.getLong("id"),
@@ -25,6 +23,7 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
                     rs.getTime("time").toLocalTime()
             );
 
+    private final SimpleJdbcInsert jdbcInsert;
     private final JdbcTemplate jdbcTemplate;
 
     public JdbcTemplateReservationRepository(JdbcTemplate jdbcTemplate) {
@@ -48,14 +47,16 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
 
     @Override
     public List<Reservation> findAll() {
-        return jdbcTemplate.query("SELECT * FROM RESERVATION", RESERVATION_ROW_MAPPER);
+        String selectAll = "SELECT * FROM RESERVATION";
+        return jdbcTemplate.query(selectAll, RESERVATION_ROW_MAPPER);
     }
 
     @Override
     public Optional<Reservation> findById(final long reservationId) {
         try {
-            Reservation reservation = jdbcTemplate.queryForObject("SELECT * FROM RESERVATION WHERE id = ?", RESERVATION_ROW_MAPPER, reservationId);
-            return Optional.of(reservation);
+            String selectById = "SELECT * FROM RESERVATION WHERE id = ?";
+            Reservation reservation = jdbcTemplate.queryForObject(selectById, RESERVATION_ROW_MAPPER, reservationId);
+            return Optional.ofNullable(reservation);
         } catch (EmptyResultDataAccessException emptyResultDataAccessException) {
             return Optional.empty();
         }
@@ -63,6 +64,7 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
 
     @Override
     public void deleteById(final long reservationId) {
-        jdbcTemplate.update("DELETE FROM reservation WHERE id = ?", reservationId);
+        String deleteById = "DELETE FROM reservation WHERE id = ?";
+        jdbcTemplate.update(deleteById, reservationId);
     }
 }

--- a/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
@@ -10,14 +10,15 @@ import java.util.List;
 @Repository
 public class JdbcTemplateReservationRepository implements ReservationRepository {
 
-    private final JdbcTemplate jdbcTemplate;
-    private final RowMapper<Reservation> reservationRowMapper = (rs, rowNum) ->
+    private static final RowMapper<Reservation> RESERVATION_ROW_MAPPER = (rs, rowNum) ->
             new Reservation(
                     rs.getLong("id"),
-                    rs.getString("name"),
-                    rs.getDate("date").toLocalDate(),
-                    rs.getTime("time").toLocalTime()
+                    rs.getString("customer_name"),
+                    rs.getDate("reservation_date").toLocalDate(),
+                    rs.getTime("reservation_time").toLocalTime()
             );
+
+    private final JdbcTemplate jdbcTemplate;
 
     public JdbcTemplateReservationRepository(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
@@ -25,6 +26,6 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
 
     @Override
     public List<Reservation> findAll() {
-        return jdbcTemplate.query("SELECT * FROM RESERVATION", reservationRowMapper);
+        return jdbcTemplate.query("SELECT * FROM RESERVATION", RESERVATION_ROW_MAPPER);
     }
 }

--- a/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
@@ -66,8 +66,8 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
 
     @Override
     public boolean existsByDateAndTime(final LocalDate date, final LocalTime time) {
-        String selectByDateAndTime = "SELECT * FROM RESERVATION" +
-                "WHERE EXISTS(SELECT * FROM RESERVATION WHERE `date` = ? AND `time` = ?)";
+        String selectByDateAndTime = "SELECT EXISTS (" +
+                "SELECT 1 FROM RESERVATION WHERE `date` = ? AND `time` = ?)";
         return jdbcTemplate.queryForObject(selectByDateAndTime, Boolean.class, date, time);
     }
 

--- a/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcTemplateReservationRepository.java
@@ -20,7 +20,7 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
     private static final RowMapper<Reservation> RESERVATION_ROW_MAPPER = (rs, rowNum) ->
             new Reservation(
                     rs.getLong("id"),
-                    rs.getString("customer_name"),
+                    rs.getString("name"),
                     rs.getDate("date").toLocalDate(),
                     rs.getTime("time").toLocalTime()
             );
@@ -41,7 +41,7 @@ public class JdbcTemplateReservationRepository implements ReservationRepository 
         long id = jdbcInsert.executeAndReturnKey(parameters).longValue();
         return new Reservation(
                 id,
-                reservation.getCustomerName(),
+                reservation.getName(),
                 reservation.getDate(),
                 reservation.getTime()
         );

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -2,6 +2,8 @@ package roomescape.repository;
 
 import roomescape.domain.Reservation;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,6 +14,8 @@ public interface ReservationRepository {
     List<Reservation> findAll();
 
     Optional<Reservation> findById(long reservationId);
+
+    boolean existsByDateAndTime(LocalDate date, LocalTime time);
 
     void deleteById(long reservationId);
 }

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -3,7 +3,6 @@ package roomescape.repository;
 import roomescape.domain.Reservation;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface ReservationRepository {
 
@@ -11,7 +10,7 @@ public interface ReservationRepository {
 
     List<Reservation> findAll();
 
-    Optional<Reservation> findById(long reservationId);
+    Reservation findById(long reservationId);
 
     void deleteById(long reservationId);
 }

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -3,6 +3,7 @@ package roomescape.repository;
 import roomescape.domain.Reservation;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservationRepository {
 
@@ -10,7 +11,7 @@ public interface ReservationRepository {
 
     List<Reservation> findAll();
 
-    Reservation findById(long reservationId);
+    Optional<Reservation> findById(long reservationId);
 
     void deleteById(long reservationId);
 }

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -1,6 +1,6 @@
 package roomescape.repository;
 
-import roomescape.entity.Reservation;
+import roomescape.domain.Reservation;
 
 import java.util.List;
 

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -3,8 +3,15 @@ package roomescape.repository;
 import roomescape.domain.Reservation;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservationRepository {
 
+    Reservation save(Reservation reservation);
+
     List<Reservation> findAll();
+
+    Optional<Reservation> findById(long reservationId);
+
+    void deleteById(long reservationId);
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -9,6 +9,7 @@ import roomescape.repository.ReservationRepository;
 
 import java.util.List;
 
+import static roomescape.global.exception.ExceptionMessage.RESERVATION_ALREADY_EXISTS;
 import static roomescape.global.exception.ExceptionMessage.RESERVATION_NOT_EXISTS;
 
 @Service
@@ -29,7 +30,7 @@ public class ReservationService {
 
     private void validateAlreadyOccupied(final Reservation reservation) {
         if (reservationRepository.existsByDateAndTime(reservation.getDate(), reservation.getTime())) {
-            throw new BadRequestException(RESERVATION_NOT_EXISTS.getMessage());
+            throw new BadRequestException(RESERVATION_ALREADY_EXISTS.getMessage());
         }
     }
 

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -4,9 +4,12 @@ import org.springframework.stereotype.Service;
 import roomescape.domain.Reservation;
 import roomescape.dto.request.CreateReservationRequest;
 import roomescape.dto.response.ReservationResponse;
+import roomescape.global.exception.NotFoundException;
 import roomescape.repository.ReservationRepository;
 
 import java.util.List;
+
+import static roomescape.global.exception.ExceptionMessage.RESERVATION_NOT_EXISTS;
 
 @Service
 public class ReservationService {
@@ -32,7 +35,8 @@ public class ReservationService {
     }
 
     public void deleteReservation(final long reservationId) {
-        Reservation reservation = reservationRepository.findById(reservationId);
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new NotFoundException(RESERVATION_NOT_EXISTS.getMessage()));
         reservationRepository.deleteById(reservation.getId());
     }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -27,13 +27,13 @@ public class ReservationService {
 
     public ReservationResponse createReservation(final CreateReservationRequest request) {
         Reservation reservation = request.toReservation();
-        validateAlreadyOccupied(reservation);
+        validateAvailability(reservation);
         validateExpiredDateTime(reservation);
         Reservation reservationWithId = reservationRepository.save(reservation);
         return new ReservationResponse(reservationWithId);
     }
 
-    private void validateAlreadyOccupied(final Reservation reservation) {
+    private void validateAvailability(final Reservation reservation) {
         if (reservationRepository.existsByDateAndTime(reservation.getDate(), reservation.getTime())) {
             throw new BadRequestException(RESERVATION_ALREADY_EXISTS.getMessage());
         }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -32,9 +32,7 @@ public class ReservationService {
     }
 
     public void deleteReservation(final long reservationId) {
-        //TODO: 커스텀 예외 추가
-        Reservation reservation = reservationRepository.findById(reservationId)
-                .orElseThrow();
+        Reservation reservation = reservationRepository.findById(reservationId);
         reservationRepository.deleteById(reservation.getId());
     }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -5,7 +5,6 @@ import roomescape.domain.Reservation;
 import roomescape.dto.request.CreateReservationRequest;
 import roomescape.dto.response.ReservationResponse;
 import roomescape.global.exception.BadRequestException;
-import roomescape.global.exception.NotFoundException;
 import roomescape.repository.ReservationRepository;
 
 import java.util.List;
@@ -43,7 +42,7 @@ public class ReservationService {
 
     public void deleteReservation(final long reservationId) {
         Reservation reservation = reservationRepository.findById(reservationId)
-                .orElseThrow(() -> new NotFoundException(RESERVATION_NOT_EXISTS.getMessage()));
+                .orElseThrow(() -> new BadRequestException(RESERVATION_NOT_EXISTS.getMessage()));
         reservationRepository.deleteById(reservation.getId());
     }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -1,9 +1,9 @@
 package roomescape.service;
 
 import org.springframework.stereotype.Service;
+import roomescape.domain.Reservation;
 import roomescape.dto.request.CreateReservationRequest;
 import roomescape.dto.response.ReservationResponse;
-import roomescape.entity.Reservation;
 import roomescape.global.exception.BadRequestException;
 import roomescape.repository.ReservationRepository;
 

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -4,20 +4,14 @@ import org.springframework.stereotype.Service;
 import roomescape.domain.Reservation;
 import roomescape.dto.request.CreateReservationRequest;
 import roomescape.dto.response.ReservationResponse;
-import roomescape.global.exception.BadRequestException;
 import roomescape.repository.ReservationRepository;
 
-import java.util.ArrayList;
 import java.util.List;
-
-import static roomescape.global.exception.ExceptionMessage.RESERVATION_NOT_EXISTS;
 
 @Service
 public class ReservationService {
 
     private final ReservationRepository reservationRepository;
-
-    private final List<Reservation> reservations = new ArrayList<>();
 
     public ReservationService(final ReservationRepository reservationRepository) {
         this.reservationRepository = reservationRepository;
@@ -25,8 +19,9 @@ public class ReservationService {
 
     public ReservationResponse createReservation(final CreateReservationRequest request) {
         Reservation reservation = request.toReservation();
-        reservations.add(reservation);
-        return new ReservationResponse(reservation);
+        //TODO: 동일한 날짜 및 시간에 예약내역 검증
+        Reservation reservationWithId = reservationRepository.save(reservation);
+        return new ReservationResponse(reservationWithId);
     }
 
     public List<ReservationResponse> getReservations() {
@@ -37,14 +32,9 @@ public class ReservationService {
     }
 
     public void deleteReservation(final long reservationId) {
-        Reservation reservation = findReservation(reservationId);
-        reservations.remove(reservation);
-    }
-
-    private Reservation findReservation(final long reservationId) {
-        return reservations.stream()
-                .filter(reservation -> reservation.isSameId(reservationId))
-                .findFirst()
-                .orElseThrow(() -> new BadRequestException(RESERVATION_NOT_EXISTS.getMessage()));
+        //TODO: 커스텀 예외 추가
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow();
+        reservationRepository.deleteById(reservation.getId());
     }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import roomescape.domain.Reservation;
 import roomescape.dto.request.CreateReservationRequest;
 import roomescape.dto.response.ReservationResponse;
+import roomescape.global.exception.BadRequestException;
 import roomescape.global.exception.NotFoundException;
 import roomescape.repository.ReservationRepository;
 
@@ -22,9 +23,15 @@ public class ReservationService {
 
     public ReservationResponse createReservation(final CreateReservationRequest request) {
         Reservation reservation = request.toReservation();
-        //TODO: 동일한 날짜 및 시간에 예약내역 검증
+        validateAlreadyOccupied(reservation);
         Reservation reservationWithId = reservationRepository.save(reservation);
         return new ReservationResponse(reservationWithId);
+    }
+
+    private void validateAlreadyOccupied(final Reservation reservation) {
+        if (reservationRepository.existsByDateAndTime(reservation.getDate(), reservation.getTime())) {
+            throw new BadRequestException(RESERVATION_NOT_EXISTS.getMessage());
+        }
     }
 
     public List<ReservationResponse> getReservations() {

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -24,7 +24,7 @@ public class ReservationService {
     }
 
     public ReservationResponse createReservation(final CreateReservationRequest request) {
-        Reservation reservation = new Reservation(request.name(), request.date(), request.time());
+        Reservation reservation = request.toReservation();
         reservations.add(reservation);
         return new ReservationResponse(reservation);
     }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -7,23 +7,28 @@ import roomescape.dto.response.ReservationResponse;
 import roomescape.global.exception.BadRequestException;
 import roomescape.repository.ReservationRepository;
 
+import java.time.Clock;
 import java.util.List;
 
+import static roomescape.global.exception.ExceptionMessage.INVALID_DATETIME;
 import static roomescape.global.exception.ExceptionMessage.RESERVATION_ALREADY_EXISTS;
 import static roomescape.global.exception.ExceptionMessage.RESERVATION_NOT_EXISTS;
 
 @Service
 public class ReservationService {
 
+    private final Clock clock;
     private final ReservationRepository reservationRepository;
 
-    public ReservationService(final ReservationRepository reservationRepository) {
+    public ReservationService(final Clock clock, final ReservationRepository reservationRepository) {
+        this.clock = clock;
         this.reservationRepository = reservationRepository;
     }
 
     public ReservationResponse createReservation(final CreateReservationRequest request) {
         Reservation reservation = request.toReservation();
         validateAlreadyOccupied(reservation);
+        validateExpiredDateTime(reservation);
         Reservation reservationWithId = reservationRepository.save(reservation);
         return new ReservationResponse(reservationWithId);
     }
@@ -31,6 +36,12 @@ public class ReservationService {
     private void validateAlreadyOccupied(final Reservation reservation) {
         if (reservationRepository.existsByDateAndTime(reservation.getDate(), reservation.getTime())) {
             throw new BadRequestException(RESERVATION_ALREADY_EXISTS.getMessage());
+        }
+    }
+
+    private void validateExpiredDateTime(final Reservation reservation) {
+        if (reservation.isExpired(clock)) {
+            throw new BadRequestException(INVALID_DATETIME.getMessage());
         }
     }
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS reservation
 (
     id      BIGINT       NOT NULL AUTO_INCREMENT,
-    customer_name    VARCHAR(255) NOT NULL,
+    name    VARCHAR(255) NOT NULL,
     `date`    DATE NOT NULL,
     `time`    TIME NOT NULL,
     PRIMARY KEY (id)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS reservation
 (
     id      BIGINT       NOT NULL AUTO_INCREMENT,
     customer_name    VARCHAR(255) NOT NULL,
-    reservation_date    DATE NOT NULL,
-    reservation_time    TIME NOT NULL,
+    `date`    DATE NOT NULL,
+    `time`    TIME NOT NULL,
     PRIMARY KEY (id)
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS reservation
 (
     id      BIGINT       NOT NULL AUTO_INCREMENT,
-    name    VARCHAR(255) NOT NULL,
+    name    VARCHAR(30) NOT NULL,
     `date`    DATE NOT NULL,
     `time`    TIME NOT NULL,
     PRIMARY KEY (id)

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
-import roomescape.entity.Reservation;
+import roomescape.domain.Reservation;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -18,7 +18,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
-import static roomescape.entity.Reservation.RESERVATION_ID;
+import static roomescape.domain.Reservation.RESERVATION_ID;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -50,7 +50,7 @@ public class MissionStepTest {
     @Test
     void 삼단계() {
         Map<String, String> params = new HashMap<>();
-        params.put("customerName", "브라운");
+        params.put("name", "브라운");
         params.put("date", "2023-08-05");
         params.put("time", "15:40");
 
@@ -84,7 +84,7 @@ public class MissionStepTest {
     @Test
     void 사단계() {
         Map<String, String> params = new HashMap<>();
-        params.put("customerName", "브라운");
+        params.put("name", "브라운");
         params.put("date", "");
         params.put("time", "");
 
@@ -116,7 +116,7 @@ public class MissionStepTest {
 
     @Test
     void 육단계() {
-        jdbcTemplate.update("INSERT INTO reservation (customer_name, date, time) VALUES (?, ?, ?)", "브라운", "2023-08-05", "15:40");
+        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "브라운", "2023-08-05", "15:40");
 
         List<Reservation> reservations = RestAssured.given().log().all()
                 .when().get("/reservations")
@@ -132,7 +132,7 @@ public class MissionStepTest {
     @Test
     void 칠단계() {
         Map<String, String> params = new HashMap<>();
-        params.put("customerName", "브라운");
+        params.put("name", "브라운");
         params.put("date", "2023-08-05");
         params.put("time", "10:00");
 

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -2,7 +2,6 @@ package roomescape;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,7 +17,6 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
-import static roomescape.domain.Reservation.RESERVATION_ID;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -26,11 +24,6 @@ public class MissionStepTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
-
-    @AfterEach
-    void tearDown() {
-        RESERVATION_ID.set(0);
-    }
 
     @Test
     void 일단계() {
@@ -134,6 +127,33 @@ public class MissionStepTest {
         Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
 
         assertThat(reservations.size()).isEqualTo(count);
+    }
+
+    @Test
+    void 칠단계() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "2023-08-05");
+        params.put("time", "10:00");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(201)
+                .header("Location", "/reservations/1");
+
+        Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        assertThat(count).isEqualTo(1);
+
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(204);
+
+        Integer countAfterDelete = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        assertThat(countAfterDelete).isEqualTo(0);
     }
 
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -2,28 +2,45 @@ package roomescape;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import roomescape.domain.Reservation;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.doReturn;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
 
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2023-08-01T00:00:00Z"), ZoneId.of("UTC"));
+    
+    @SpyBean
+    private Clock clock;
+
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        doReturn(FIXED_CLOCK.instant()).when(clock).instant();
+        doReturn(FIXED_CLOCK.getZone()).when(clock).getZone();
+    }
 
     @Test
     void 일단계() {
@@ -52,7 +69,7 @@ public class MissionStepTest {
         Map<String, String> params = new HashMap<>();
         params.put("name", "브라운");
         params.put("date", "2023-08-05");
-        params.put("time", "15:40");
+        params.put("time", "15:00");
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
@@ -116,7 +133,7 @@ public class MissionStepTest {
 
     @Test
     void 육단계() {
-        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "브라운", "2023-08-05", "15:40");
+        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "브라운", "2023-08-05", "15:00");
 
         List<Reservation> reservations = RestAssured.given().log().all()
                 .when().get("/reservations")

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -47,46 +47,46 @@ public class MissionStepTest {
                 .body("$.size()", is(0));
     }
 
-//    @Test
-//    void 삼단계() {
-//        Map<String, String> params = new HashMap<>();
-//        params.put("name", "브라운");
-//        params.put("date", "2023-08-05");
-//        params.put("time", "15:40");
-//
-//        RestAssured.given().log().all()
-//                .contentType(ContentType.JSON)
-//                .body(params)
-//                .when().post("/reservations")
-//                .then().log().all()
-//                .statusCode(201)
-//                .header("Location", "/reservations/1")
-//                .body("id", is(1));
-//
-//        RestAssured.given().log().all()
-//                .when().get("/reservations")
-//                .then().log().all()
-//                .statusCode(200)
-//                .body("$.size()", is(1));
-//
-//        RestAssured.given().log().all()
-//                .when().delete("/reservations/1")
-//                .then().log().all()
-//                .statusCode(204);
-//
-//        RestAssured.given().log().all()
-//                .when().get("/reservations")
-//                .then().log().all()
-//                .statusCode(200)
-//                .body("$.size()", is(0));
-//    }
+    @Test
+    void 삼단계() {
+        Map<String, String> params = new HashMap<>();
+        params.put("customerName", "브라운");
+        params.put("date", "2023-08-05");
+        params.put("time", "15:40");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(201)
+                .header("Location", "/reservations/1")
+                .body("id", is(1));
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("$.size()", is(1));
+
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(204);
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("$.size()", is(0));
+    }
 
     @Test
     void 사단계() {
         Map<String, String> params = new HashMap<>();
-        params.put("customer_name", "브라운");
-        params.put("reservation_date", "");
-        params.put("reservation_time", "");
+        params.put("customerName", "브라운");
+        params.put("date", "");
+        params.put("time", "");
 
         // 필요한 인자가 없는 경우
         RestAssured.given().log().all()
@@ -116,7 +116,7 @@ public class MissionStepTest {
 
     @Test
     void 육단계() {
-        jdbcTemplate.update("INSERT INTO reservation (customer_name, reservation_date, reservation_time) VALUES (?, ?, ?)", "브라운", "2023-08-05", "15:40");
+        jdbcTemplate.update("INSERT INTO reservation (customer_name, date, time) VALUES (?, ?, ?)", "브라운", "2023-08-05", "15:40");
 
         List<Reservation> reservations = RestAssured.given().log().all()
                 .when().get("/reservations")
@@ -132,7 +132,7 @@ public class MissionStepTest {
     @Test
     void 칠단계() {
         Map<String, String> params = new HashMap<>();
-        params.put("name", "브라운");
+        params.put("customerName", "브라운");
         params.put("date", "2023-08-05");
         params.put("time", "10:00");
 
@@ -155,5 +155,4 @@ public class MissionStepTest {
         Integer countAfterDelete = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
         assertThat(countAfterDelete).isEqualTo(0);
     }
-
 }

--- a/src/test/java/roomescape/domain/ReservationTest.java
+++ b/src/test/java/roomescape/domain/ReservationTest.java
@@ -7,49 +7,80 @@ import org.junit.jupiter.params.provider.ValueSource;
 import roomescape.global.exception.BadRequestException;
 import roomescape.global.exception.ExceptionMessage;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ReservationTest {
 
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2025-02-17T10:00:00Z"), ZoneId.of("UTC"));
+
     @Test
     void 예약을_생성할_수_있다() {
-        assertThatCode(() -> new Reservation("김철수", LocalDate.now(), LocalTime.now()))
+        assertThatCode(() -> new Reservation("김철수", LocalDate.of(2025, 2, 19), LocalTime.of(13, 0)))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 현재보다_과거_시간대의_예약을_생성하면_true를_반환한다() {
+        // given
+        Reservation reservation = new Reservation("김철수", LocalDate.of(2025, 2, 17), LocalTime.of(9, 0));
+        // when &  then
+        assertThat(reservation.isExpired(FIXED_CLOCK)).isTrue();
+    }
+
+    @Test
+    void 현재_이후_시간대의_예약을_생성하면_false를_반환한다() {
+        // given
+        Reservation reservation = new Reservation("김철수", LocalDate.of(2025, 2, 17), LocalTime.of(11, 0));
+        // when &  then
+        assertThat(reservation.isExpired(FIXED_CLOCK)).isFalse();
     }
 
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {" ", "김", "아야어여오요우유으이이"})
     void 이름_길이가_2보다_작거나_19보다_크면_오류_발생(String name) {
-        assertThatThrownBy(() -> new Reservation(name, LocalDate.now(), LocalTime.MIN))
+        assertThatThrownBy(() -> new Reservation(name, LocalDate.of(2025, 2, 19), LocalTime.of(13, 0)))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessageContaining(
+                .hasMessage(
                         ExceptionMessage.INVALID_NAME.getMessage());
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"kim", "나자바!", "철수 Kim"})
     void 이름에_한글_외_다른_문자_넣을시_오류_발생(String name) {
-        assertThatThrownBy(() -> new Reservation(name, LocalDate.now(), LocalTime.MIN))
+        assertThatThrownBy(() -> new Reservation(name, LocalDate.of(2025, 2, 19), LocalTime.of(13, 0)))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessageContaining(
+                .hasMessage(
                         ExceptionMessage.INVALID_NAME.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 30, 55})
+    void 시간이_정각_단위가_아니면_예외가_발생한다(int time) {
+        assertThatThrownBy(() -> new Reservation("김철수", LocalDate.of(2025, 2, 19), LocalTime.of(13, time)))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(
+                        ExceptionMessage.INVALID_TIME.getMessage());
     }
 
     @Test
     void 필수_인자_입력하지_않을시_오류_발생() {
         assertAll(
-                () -> assertThatThrownBy(() -> new Reservation("김철수", null, LocalTime.MIN))
+                () -> assertThatThrownBy(() -> new Reservation("김철수", null, LocalTime.of(13, 0)))
                         .isInstanceOf(BadRequestException.class)
-                        .hasMessageContaining(ExceptionMessage.INVALID_DATE.getMessage()),
+                        .hasMessage(ExceptionMessage.INVALID_DATE.getMessage()),
 
-                () -> assertThatThrownBy(() -> new Reservation("김철수", LocalDate.now(), null))
+                () -> assertThatThrownBy(() -> new Reservation("김철수", LocalDate.of(2025, 2, 19), null))
                         .isInstanceOf(BadRequestException.class)
-                        .hasMessageContaining(ExceptionMessage.INVALID_TIME.getMessage()));
+                        .hasMessage(ExceptionMessage.INVALID_TIME.getMessage()));
     }
 }

--- a/src/test/java/roomescape/domain/ReservationTest.java
+++ b/src/test/java/roomescape/domain/ReservationTest.java
@@ -1,4 +1,4 @@
-package roomescape.entity;
+package roomescape.domain;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/roomescape/domain/ReservationTest.java
+++ b/src/test/java/roomescape/domain/ReservationTest.java
@@ -47,7 +47,7 @@ class ReservationTest {
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {" ", "김", "아야어여오요우유으이이"})
-    void 이름_길이가_2보다_작거나_19보다_크면_오류_발생(String name) {
+    void 이름_길이가_2보다_작거나_10보다_크면_오류_발생(String name) {
         assertThatThrownBy(() -> new Reservation(name, LocalDate.of(2025, 2, 19), LocalTime.of(13, 0)))
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(

--- a/src/test/java/roomescape/domain/ReservationTest.java
+++ b/src/test/java/roomescape/domain/ReservationTest.java
@@ -47,20 +47,18 @@ class ReservationTest {
     @ParameterizedTest
     @NullAndEmptySource
     @ValueSource(strings = {" ", "김", "아야어여오요우유으이이"})
-    void 이름_길이가_2보다_작거나_10보다_크면_오류_발생(String name) {
+    void 이름_길이가_2보다_작거나_10보다_크면_예외가_발생한다(String name) {
         assertThatThrownBy(() -> new Reservation(name, LocalDate.of(2025, 2, 19), LocalTime.of(13, 0)))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage(
-                        ExceptionMessage.INVALID_NAME.getMessage());
+                .hasMessage(ExceptionMessage.INVALID_NAME.getMessage());
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"kim", "나자바!", "철수 Kim"})
-    void 이름에_한글_외_다른_문자_넣을시_오류_발생(String name) {
+    void 이름에_한글_외_다른_문자_넣을시_예외가_발생한다(String name) {
         assertThatThrownBy(() -> new Reservation(name, LocalDate.of(2025, 2, 19), LocalTime.of(13, 0)))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage(
-                        ExceptionMessage.INVALID_NAME.getMessage());
+                .hasMessage(ExceptionMessage.INVALID_NAME.getMessage());
     }
 
     @ParameterizedTest
@@ -68,12 +66,11 @@ class ReservationTest {
     void 시간이_정각_단위가_아니면_예외가_발생한다(int time) {
         assertThatThrownBy(() -> new Reservation("김철수", LocalDate.of(2025, 2, 19), LocalTime.of(13, time)))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessage(
-                        ExceptionMessage.INVALID_TIME.getMessage());
+                .hasMessage(ExceptionMessage.INVALID_TIME.getMessage());
     }
 
     @Test
-    void 필수_인자_입력하지_않을시_오류_발생() {
+    void 필수_인자_입력하지_않을시_예외가_발생한다() {
         assertAll(
                 () -> assertThatThrownBy(() -> new Reservation("김철수", null, LocalTime.of(13, 0)))
                         .isInstanceOf(BadRequestException.class)

--- a/src/test/java/roomescape/repository/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/repository/ReservationRepositoryTest.java
@@ -1,0 +1,98 @@
+package roomescape.repository;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import roomescape.domain.Reservation;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@JdbcTest
+@Import(JdbcTemplateReservationRepository.class)
+class ReservationRepositoryTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.update("TRUNCATE TABLE RESERVATION RESTART IDENTITY");
+    }
+
+    @Test
+    void 예약을_생성한다() {
+        // given
+        Reservation reservation = new Reservation(1L, "김철수", LocalDate.of(2025, 2, 19), LocalTime.of(13, 0));
+        // when
+        Reservation savedReservation = reservationRepository.save(reservation);
+        // then
+        assertAll(
+                () -> assertThat(savedReservation.getId()).isEqualTo(1L),
+                () -> assertThat(savedReservation.getName()).isEqualTo("김철수"),
+                () -> assertThat(savedReservation.getDate()).isEqualTo("2025-02-19"),
+                () -> assertThat(savedReservation.getTime()).isEqualTo("13:00")
+        );
+    }
+
+    @Test
+    void 아이디를_통해_특정_예약을_조회한다() {
+        // given
+        Reservation reservation = new Reservation(1L, "김철수", LocalDate.of(2025, 2, 19), LocalTime.of(13, 0));
+        Reservation savedReservation = reservationRepository.save(reservation);
+        // when
+        Optional<Reservation> foundReservation = reservationRepository.findById(savedReservation.getId());
+        // then
+        assertThat(foundReservation).isPresent();
+        assertThat(foundReservation.get().getName()).isEqualTo("김철수");
+    }
+
+    @Test
+    void 모든_예약을_조회한다() {
+        // given
+        Reservation reservation1 = new Reservation(1L, "김철수", LocalDate.of(2025, 2, 19), LocalTime.of(13, 0));
+        Reservation reservation2 = new Reservation(2L, "김영희", LocalDate.of(2025, 2, 19), LocalTime.of(14, 0));
+        reservationRepository.save(reservation1);
+        reservationRepository.save(reservation2);
+        // when
+        List<Reservation> reservations = reservationRepository.findAll();
+        // then
+        assertThat(reservations).hasSize(2);
+    }
+
+    @Test
+    void 해당_날짜_및_시간에_예약이_존재하면_true를_반환한다() {
+        // given
+        LocalDate date = LocalDate.of(2025, 2, 19);
+        LocalTime time = LocalTime.of(13, 0);
+        Reservation reservation = new Reservation(1L, "김철수", date, time);
+        reservationRepository.save(reservation);
+        // when
+        boolean exists = reservationRepository.existsByDateAndTime(date, time);
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @Test
+    void 아이디를_통해_특정_예약을_삭제한다() {
+        // given
+        Reservation reservation = new Reservation(1L, "김철수", LocalDate.of(2025, 2, 19), LocalTime.of(13, 0));
+        Reservation savedReservation = reservationRepository.save(reservation);
+        // when
+        reservationRepository.deleteById(savedReservation.getId());
+        // then
+        Optional<Reservation> foundReservation = reservationRepository.findById(savedReservation.getId());
+        assertThat(foundReservation).isEmpty();
+    }
+}

--- a/src/test/java/roomescape/repository/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/repository/ReservationRepositoryTest.java
@@ -34,7 +34,7 @@ class ReservationRepositoryTest {
     @Test
     void 예약을_생성한다() {
         // given
-        Reservation reservation = new Reservation(1L, "김철수", LocalDate.of(2025, 2, 19), LocalTime.of(13, 0));
+        Reservation reservation = new Reservation("김철수", LocalDate.of(2025, 2, 19), LocalTime.of(13, 0));
         // when
         Reservation savedReservation = reservationRepository.save(reservation);
         // then
@@ -49,13 +49,18 @@ class ReservationRepositoryTest {
     @Test
     void 아이디를_통해_특정_예약을_조회한다() {
         // given
-        Reservation reservation = new Reservation(1L, "김철수", LocalDate.of(2025, 2, 19), LocalTime.of(13, 0));
+        Reservation reservation = new Reservation("김철수", LocalDate.of(2025, 2, 19), LocalTime.of(13, 0));
         Reservation savedReservation = reservationRepository.save(reservation);
         // when
         Optional<Reservation> foundReservation = reservationRepository.findById(savedReservation.getId());
         // then
-        assertThat(foundReservation).isPresent();
-        assertThat(foundReservation.get().getName()).isEqualTo("김철수");
+        assertAll(
+                () -> assertThat(foundReservation).isPresent(),
+                () -> assertThat(savedReservation.getId()).isEqualTo(1L),
+                () -> assertThat(savedReservation.getName()).isEqualTo("김철수"),
+                () -> assertThat(savedReservation.getDate()).isEqualTo("2025-02-19"),
+                () -> assertThat(savedReservation.getTime()).isEqualTo("13:00")
+        );
     }
 
     @Test

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -1,5 +1,6 @@
 package roomescape.service;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,6 +18,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -28,34 +30,75 @@ class ReservationServiceTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.update("TRUNCATE TABLE RESERVATION");
+    }
+
+    @Test
+    void 예약을_생성할_수_있다() {
+        // given
+        CreateReservationRequest request = createReservationRequest("김철수", 2025, 2, 18, 13, 0);
+        // when
+        ReservationResponse response = reservationService.createReservation(request);
+        // then
+        assertAll(
+                () -> assertThat(response.name()).isEqualTo(request.name()),
+                () -> assertThat(response.date()).isEqualTo(request.date()),
+                () -> assertThat(response.time()).isEqualTo(request.time())
+        );
+    }
+
+    @Test
+    void 동시간대에_예약이_존재한다면_예외가_발생한다() {
+        // given
+        CreateReservationRequest request1 = createReservationRequest("김철수", 2025, 2, 18, 13, 0);
+        reservationService.createReservation(request1);
+        CreateReservationRequest request2 = createReservationRequest("김영희", 2025, 2, 18, 13, 0);
+        // when & then
+        assertThatThrownBy(() -> reservationService.createReservation(request2))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(
+                        ExceptionMessage.RESERVATION_ALREADY_EXISTS.getMessage());
+    }
+
     @Test
     void 총_예약건수를_조회할_수_있다() {
         // given
-        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "예약생성못해쿼리투입", "2025-02-12", "15:00");
+        CreateReservationRequest request1 = createReservationRequest("김철수", 2025, 2, 18, 13, 0);
+        CreateReservationRequest request2 = createReservationRequest("김영희", 2025, 2, 18, 14, 0);
+        reservationService.createReservation(request1);
+        reservationService.createReservation(request2);
         // when
-        List<ReservationResponse> reservations = reservationService.getReservations();
+        List<ReservationResponse> reservationResponses = reservationService.getReservations();
         // then
-        assertThat(reservations.size() == 1).isTrue();
+        assertThat(reservationResponses.size() == 2).isTrue();
     }
 
     @Test
     void 예약을_삭제할_수_있다() {
         // given
-        CreateReservationRequest request = new CreateReservationRequest(
-                "김철수",
-                LocalDate.of(2025, 2, 6),
-                LocalTime.of(12, 30));
-        ReservationResponse reservation = reservationService.createReservation(request);
+        CreateReservationRequest request = createReservationRequest("김철수", 2025, 2, 18, 13, 0);
+        ReservationResponse response = reservationService.createReservation(request);
         // when & then
-        assertThatCode(() -> reservationService.deleteReservation(reservation.id()))
+        assertThatCode(() -> reservationService.deleteReservation(response.id()))
                 .doesNotThrowAnyException();
     }
 
     @Test
-    void 존재하지_않는_예약을_삭제하는_경우_오류_발생() {
+    void 존재하지_않는_예약을_삭제하는_경우_예외가_발생한다() {
         assertThatThrownBy(() -> reservationService.deleteReservation(1))
                 .isInstanceOf(BadRequestException.class)
-                .hasMessageContaining(
+                .hasMessage(
                         ExceptionMessage.RESERVATION_NOT_EXISTS.getMessage());
+    }
+
+    private CreateReservationRequest createReservationRequest(String name,
+                                                              int year, int month, int dayOfMonth,
+                                                              int hour, int minute) {
+        return new CreateReservationRequest(
+                name,
+                LocalDate.of(year, month, dayOfMonth),
+                LocalTime.of(hour, minute));
     }
 }

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -5,11 +5,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.dto.request.CreateReservationRequest;
 import roomescape.dto.response.ReservationResponse;
+import roomescape.global.exception.BadRequestException;
+import roomescape.global.exception.ExceptionMessage;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -24,31 +31,31 @@ class ReservationServiceTest {
     @Test
     void 총_예약건수를_조회할_수_있다() {
         // given
-        jdbcTemplate.update("INSERT INTO reservation (customer_name, reservation_date, reservation_time) VALUES (?, ?, ?)", "예약생성못해쿼리투입", "2025-02-12", "15:00");
+        jdbcTemplate.update("INSERT INTO reservation (customer_name, date, time) VALUES (?, ?, ?)", "예약생성못해쿼리투입", "2025-02-12", "15:00");
         // when
         List<ReservationResponse> reservations = reservationService.getReservations();
         // then
         assertThat(reservations.size() == 1).isTrue();
     }
 
-//    @Test
-//    void 예약을_삭제할_수_있다() {
-//        // given
-//        CreateReservationRequest request = new CreateReservationRequest(
-//                "김철수",
-//                LocalDate.of(2025, 2, 6),
-//                LocalTime.of(12, 30));
-//        reservationService.createReservation(request);
-//        // when & then
-//        assertThatCode(() -> reservationService.deleteReservation(1))
-//                .doesNotThrowAnyException();
-//    }
-//
-//    @Test
-//    void 존재하지_않는_예약을_삭제하는_경우_오류_발생() {
-//        assertThatThrownBy(() -> reservationService.deleteReservation(1))
-//                .isInstanceOf(BadRequestException.class)
-//                .hasMessageContaining(
-//                        ExceptionMessage.RESERVATION_NOT_EXISTS.getMessage());
-//    }
+    @Test
+    void 예약을_삭제할_수_있다() {
+        // given
+        CreateReservationRequest request = new CreateReservationRequest(
+                "김철수",
+                LocalDate.of(2025, 2, 6),
+                LocalTime.of(12, 30));
+        ReservationResponse reservation = reservationService.createReservation(request);
+        // when & then
+        assertThatCode(() -> reservationService.deleteReservation(reservation.id()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 존재하지_않는_예약을_삭제하는_경우_오류_발생() {
+        assertThatThrownBy(() -> reservationService.deleteReservation(1))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessageContaining(
+                        ExceptionMessage.RESERVATION_NOT_EXISTS.getMessage());
+    }
 }

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -1,9 +1,11 @@
 package roomescape.service;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import roomescape.dto.request.CreateReservationRequest;
@@ -11,24 +13,39 @@ import roomescape.dto.response.ReservationResponse;
 import roomescape.global.exception.BadRequestException;
 import roomescape.global.exception.ExceptionMessage;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.doReturn;
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class ReservationServiceTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2025-02-17T10:00:00Z"), ZoneId.of("UTC"));
+
+    @SpyBean
+    private Clock clock;
 
     @Autowired
     private ReservationService reservationService;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        doReturn(FIXED_CLOCK.instant()).when(clock).instant();
+        doReturn(FIXED_CLOCK.getZone()).when(clock).getZone();
+    }
 
     @AfterEach
     void tearDown() {
@@ -60,6 +77,17 @@ class ReservationServiceTest {
                 .isInstanceOf(BadRequestException.class)
                 .hasMessage(
                         ExceptionMessage.RESERVATION_ALREADY_EXISTS.getMessage());
+    }
+
+    @Test
+    void 현재_시간_이전의_예약_생성_시_예외가_발생한다() {
+        // given
+        CreateReservationRequest request = createReservationRequest("김철수", 2025, 2, 17, 9, 0);
+        // when & then
+        assertThatThrownBy(() -> reservationService.createReservation(request))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage(
+                        ExceptionMessage.INVALID_DATETIME.getMessage());
     }
 
     @Test

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -100,7 +100,7 @@ class ReservationServiceTest {
         // when
         List<ReservationResponse> reservationResponses = reservationService.getReservations();
         // then
-        assertThat(reservationResponses.size() == 2).isTrue();
+        assertThat(reservationResponses).hasSize(2);
     }
 
     @Test

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -106,11 +106,11 @@ class ReservationServiceTest {
         // given
         CreateReservationRequest request = createReservationRequest("김철수", 2025, 2, 18, 13, 0);
         ReservationResponse response = reservationService.createReservation(request);
-        int reservationSizeBeforeDelete = reservationService.getReservations().size();
+        int initialReservationSize = reservationService.getReservations().size();
         // when
         reservationService.deleteReservation(response.id());
         // then
-        assertThat(reservationService.getReservations()).hasSize(reservationSizeBeforeDelete - 1);
+        assertThat(reservationService.getReservations()).hasSize(initialReservationSize - 1);
     }
 
     @Test

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.annotation.DirtiesContext;
 import roomescape.dto.request.CreateReservationRequest;
 import roomescape.dto.response.ReservationResponse;
 import roomescape.global.exception.BadRequestException;
@@ -24,9 +23,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.doReturn;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
-@SpringBootTest
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class ReservationServiceTest {
 
     private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2025-02-17T10:00:00Z"), ZoneId.of("UTC"));

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -21,7 +21,6 @@ import java.time.ZoneId;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.doReturn;
@@ -108,9 +107,11 @@ class ReservationServiceTest {
         // given
         CreateReservationRequest request = createReservationRequest("김철수", 2025, 2, 18, 13, 0);
         ReservationResponse response = reservationService.createReservation(request);
-        // when & then
-        assertThatCode(() -> reservationService.deleteReservation(response.id()))
-                .doesNotThrowAnyException();
+        int reservationSizeBeforeDelete = reservationService.getReservations().size();
+        // when
+        reservationService.deleteReservation(response.id());
+        // then
+        assertThat(reservationService.getReservations()).hasSize(reservationSizeBeforeDelete - 1);
     }
 
     @Test

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -31,7 +31,7 @@ class ReservationServiceTest {
     @Test
     void 총_예약건수를_조회할_수_있다() {
         // given
-        jdbcTemplate.update("INSERT INTO reservation (customer_name, date, time) VALUES (?, ?, ?)", "예약생성못해쿼리투입", "2025-02-12", "15:00");
+        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "예약생성못해쿼리투입", "2025-02-12", "15:00");
         // when
         List<ReservationResponse> reservations = reservationService.getReservations();
         // then


### PR DESCRIPTION
안녕하세요 비토 :)
지난번 리뷰 정말 유익했어요!! 다시 한번 감사드립니다🙇🏻‍♀️
말씀해주신 피드백을 최대한 반영해보았답니다..!
테스트 코드도 열심히 작성해봤는데,,,아직 많이 부족하네요🥹
리뷰 남겨주시면 공부해서 개선시켜 보겠습니다! 
이번 PR도 잘 부탁드립니다!

## 🛠️ 주요 변경사항 및 고려한 부분

- **domain 객체 생성 책임 dto로 위치 변경(`toReservation()`메서드)**
    - 나중에 필드가 변경될 수 있음을 대비하여 기존에 서비스 레이어에서 노출되어 있던 객체 생성 메서드 위치를 dto로 변경해주었습니다.
    캡슐화로 인해, domain 또는 dto 필드가 변경되어도 수정해야 할 부분이 줄어든다는 장점을 느낄 수 있었습니다.

- **entity 패키지 -> domain 패키지로 패키지명 변경**
    - 현재 `Reservation` 객체는 비지니스 로직(예약 가능한 시간인지 등)을 포함하고 있기 때문에 entity의 범위를 벗어난다고 생각하여 domain으로 변경해주었습니다.

- **`RESERVATION_ROW_MAPPER` 상수 선언**
    - 클래스가 로드될 때 한 번만 초기화될 수 있도록 row mapper를 상수 처리해주었습니다.
    
    [**상수와 필드 차이점**]
    **상수**는 처음 프로그램 실행 시 단 한 번만 초기화되므로 메모리를 효율적으로 사용한다는 특징을 지니고 있습니다. 또한 전역적으로 공유하고 있기 때문에 상태를 지니면 않는 특징이 존재합니다.
    반면 **필드**는 클래스 인스턴스 생성 시마다 초기화되므로, 객체가 여러번 생성되어 메모리 사용량이 증가하는 특징을 지닙니다. 따라서 주로 독립적인 상태가 필요할 때 사용합니다.

    [**결론**]
    row mapper는 상태를 가지고 있지 않아 생성되는 클래스마다 row mapper가 달라져야할 이유가 없기 때문에 상수로 선언하여 메모리 효율성을 높였습니다.

- **AtomicLong 제거 후 `jdbcInsert` 도입**
    -  jdbcInsert를 통해 삽입 직후 조회(READ) 과정없이 삽입된 데이터의 id 값을 얻을 수 있었습니다.
    
- **예외처리 추가 및 테스트 코드 보완**
    - 예약 생성
        - 동일한 날짜 및 시간에 예약이 존재하는 경우
        - 현재 시간보다 이전 시간으로 예약을 생성하려는 경우
        - 시간이 1시간 단위가 아닌 경우
    - 예약 조회
        - 특정 예약이 존재하지 않는 경우

- **mysql 예약어와 동일한 컬럼 백틱 처리**
    -  지난번에 예약어와 충돌하는 컬럼 이름을 구체적으로 변경했었는데요..
    js 파일에 있는 변수들과 일치하지 않아 데이터가 null로 들어오는 이슈가 발생해서 백틱으로 감싸는 것으로 변경하였습니다.

## 🙋🏻 질문

- `LocalDate.now()`를 테스트하기 위한 방법으로 `Clock`을 주로 활용하는지,
이외에도 활용되는 다른 테스트 방법이 존재하는지 궁금합니다!
    - 테스트 코드는 항상 실행할 때마다 동일한 결과를 반환해야 한다고 생각합니다.
근데 이번에 시간 관련 로직을 다루게 되면서, `LocalDate.now()`로 인해 테스트 결과가 매번 동일한 결과를 반환하지 않는 상황을 겪었습니다. 이를 해결하기 위한 방법으로 `Clock`을 처음으로 사용해보았는데, 맞게 활용 했는지 궁금합니다.
 
- DB에 해당 데이터가 존재하지 않는 경우: Http Status Code는 404 vs 400?
    - db에 원하는 데이터가 존재하지 않는 경우 클라이언트가 요청한 리소스를 찾지 못했다는 의미를 나타내는 NOT_FOUND(404)를 띄워주고 싶었습니다.
    하지만 찾아보니 404 Not Found는 API URI를 조회하지 못했다는 의미가 더 강하고,
    미션스텝테스트에서도 400으로 처리를 해두어서 저도 400 Bad Request로 처리하였습니다.
    하지만 400이 맞는 상태 코드인지, 아니면 팀 컨벤션에따라 404로도 표현할 수 있는 건지 궁금합니다.

- 지난번 리뷰에서 비토는 평소 개발 시 인터페이스 없이 각각 구현해서 사용하신다고 하셨는데요.
그 이유와 각각 repository를 구현해서 사용했을 때의 느끼신 장단점이 궁금합니다!

> 러키는 지금 필드를 ReservationRepository가 아닌 List로 두면 스프링이 알아서 구현체 전체를 리스트로 만들어 넣어준다는 것을 알고 계신가요? 저는 이렇게 List로 받고 내부에 isHandle과 같은 메소드를 만들어 어떤 상황에 어떤 구현체가 사용가능한지 정의해서 필요한 구현체를 뽑아서 쓰는 방법을 선호합니다!😊😊
추가로 덧붙이자면 전 Repository계층을 인터페이스로 만들어 전체 Repository를 하나로 묶는 방식은 그리 선호하지 않습니다. 차라리 JpaRepository, JdbcRepository 둘 다 상속없이 각각 구현해서 사용하는 편이에요😊😊