### PR TITLE
[Spring JDBC] 박희원 미션 제출합니다

### DIFF
--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -35,16 +35,10 @@ public class ReservationController {
 
     @PostMapping
     public ResponseEntity<Reservation> createReservation(@RequestBody Reservation reservation) {
-        Reservation newReservation = new Reservation(
-                0, //이후 데이터베이스에서 자동 생성된 아이디로 대체
-                reservation.getName(),
-                reservation.getDate(),
-                reservation.getTime()
-        );
 
-        Reservation savedReservation = reservationJdbcDAO.save(newReservation);
-        return ResponseEntity.created(URI.create("/reservations/" + savedReservation.getId()))
-                .body(savedReservation);
+        Reservation newReservation = reservationJdbcDAO.save(reservation);
+        return ResponseEntity.created(URI.create("/reservations/" + newReservation.getId()))
+                .body(newReservation);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -1,7 +1,6 @@
 package roomescape.controller;
 
 import java.net.URI;
-import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import java.util.List;
@@ -34,7 +33,7 @@ public class ReservationController {
     @PostMapping
     public ResponseEntity<Reservation> createReservation(@RequestBody Reservation reservation) {
 
-        Reservation newReservation = reservationJdbcDAO.save(reservation);
+        Reservation newReservation = reservationJdbcDAO.create(reservation);
         return ResponseEntity.created(URI.create("/reservations/" + newReservation.getId()))
                 .body(newReservation);
     }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -21,8 +21,6 @@ import roomescape.entity.Reservation;
 @RequestMapping("/reservations")
 public class ReservationController {
 
-    private final List<Reservation> reservations = new ArrayList<>();
-    private final AtomicLong reservationId = new AtomicLong(1);
     private final ReservationJdbcDAO reservationJdbcDAO;
 
     public ReservationController(ReservationJdbcDAO reservationJdbcDAO) {
@@ -38,15 +36,15 @@ public class ReservationController {
     @PostMapping
     public ResponseEntity<Reservation> createReservation(@RequestBody Reservation reservation) {
         Reservation newReservation = new Reservation(
-                reservationId.getAndIncrement(),
+                0, //이후 데이터베이스에서 자동 생성된 아이디로 대체
                 reservation.getName(),
                 reservation.getDate(),
                 reservation.getTime()
         );
 
-        reservationJdbcDAO.save(newReservation);
-        return ResponseEntity.created(URI.create("/reservations/" + newReservation.getId()))
-                .body(newReservation);
+        Reservation savedReservation = reservationJdbcDAO.save(newReservation);
+        return ResponseEntity.created(URI.create("/reservations/" + savedReservation.getId()))
+                .body(savedReservation);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -4,7 +4,6 @@ import java.net.URI;
 import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,7 +30,6 @@ public class ReservationController {
     public List<Reservation> getReservations() {
         return reservationJdbcDAO.getAll();
     }
-
 
     @PostMapping
     public ResponseEntity<Reservation> createReservation(@RequestBody Reservation reservation) {

--- a/src/main/java/roomescape/dao/ReservationDAO.java
+++ b/src/main/java/roomescape/dao/ReservationDAO.java
@@ -5,15 +5,11 @@ import roomescape.entity.Reservation;
 
 public interface ReservationDAO {
 
-    void save(Reservation reservation);
+    Reservation save(Reservation reservation);
 
     List<Reservation> getAll();
 
-    void update(Reservation reservation);
-
     void delete(long id);
-
-    int count();
 
     Reservation getById(int id);
 

--- a/src/main/java/roomescape/dao/ReservationDAO.java
+++ b/src/main/java/roomescape/dao/ReservationDAO.java
@@ -5,7 +5,7 @@ import roomescape.entity.Reservation;
 
 public interface ReservationDAO {
 
-    Reservation save(Reservation reservation);
+    Reservation create(Reservation reservation);
 
     List<Reservation> getAll();
 

--- a/src/main/java/roomescape/dao/ReservationDAO.java
+++ b/src/main/java/roomescape/dao/ReservationDAO.java
@@ -11,6 +11,6 @@ public interface ReservationDAO {
 
     void delete(long id);
 
-    Reservation getById(int id);
+    Reservation getById(long id);
 
 }

--- a/src/main/java/roomescape/dao/ReservationJdbcDAO.java
+++ b/src/main/java/roomescape/dao/ReservationJdbcDAO.java
@@ -76,7 +76,6 @@ public class ReservationJdbcDAO implements ReservationDAO {
         } catch (EmptyResultDataAccessException e) {
             throw new DataInvalidException("해당 ID의 예약을 찾을 수 없습니다 : " + e.getMessage());
         }
-
     }
 
 }

--- a/src/main/java/roomescape/dao/ReservationJdbcDAO.java
+++ b/src/main/java/roomescape/dao/ReservationJdbcDAO.java
@@ -1,13 +1,13 @@
 package roomescape.dao;
 
-import java.sql.PreparedStatement;
-import java.sql.Statement;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import javax.sql.DataSource;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.support.GeneratedKeyHolder;
-import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 import roomescape.entity.Reservation;
 import roomescape.exception.DataInvalidException;
@@ -18,29 +18,29 @@ public class ReservationJdbcDAO implements ReservationDAO {
 
     private final JdbcTemplate jdbcTemplate;
     private final RowMapper<Reservation> rowMapper = new ReservationRowMapper();
+    private final SimpleJdbcInsert simpleJdbcInsert;
 
-    public ReservationJdbcDAO(JdbcTemplate jdbcTemplate) {
+    public ReservationJdbcDAO(JdbcTemplate jdbcTemplate, DataSource dataSource) {
         this.jdbcTemplate = jdbcTemplate;
+        this.simpleJdbcInsert = new SimpleJdbcInsert(dataSource)
+                .withTableName("reservation")
+                .usingGeneratedKeyColumns("id");
+
     }
 
     @Override
     public Reservation save(Reservation reservation) {
 
-        String sql = "INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)";
-        KeyHolder keyHolder = new GeneratedKeyHolder();
-
         try {
-            jdbcTemplate.update(connection -> {
-                PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
-                ps.setString(1, reservation.getName());
-                ps.setDate(2, java.sql.Date.valueOf(reservation.getDate()));
-                ps.setTime(3, java.sql.Time.valueOf(reservation.getTime()));
-                return ps;
-            }, keyHolder);
+            Map<String, Object> parameters = new HashMap<>();
+            parameters.put("name", reservation.getName());
+            parameters.put("date", reservation.getDate());
+            parameters.put("time", reservation.getTime());
 
-            long generatedId = keyHolder.getKey().longValue();
+            Number generatedId = simpleJdbcInsert.executeAndReturnKey(parameters);
 
-            return new Reservation(generatedId, reservation.getName(), reservation.getDate(), reservation.getTime());
+            return new Reservation(generatedId.longValue(), reservation.getName(), reservation.getDate(),
+                    reservation.getTime());
 
         } catch (DataInvalidException e) {
             throw new DataInvalidException(e.getMessage());

--- a/src/main/java/roomescape/dao/ReservationJdbcDAO.java
+++ b/src/main/java/roomescape/dao/ReservationJdbcDAO.java
@@ -29,7 +29,7 @@ public class ReservationJdbcDAO implements ReservationDAO {
     }
 
     @Override
-    public Reservation save(Reservation reservation) {
+    public Reservation create(Reservation reservation) {
 
         try {
 
@@ -65,7 +65,7 @@ public class ReservationJdbcDAO implements ReservationDAO {
             throw new DataInvalidException("예약을 찾을 수 없습니다. ID: " + id);
         }
     }
-    
+
 
     @Override
     public Reservation getById(long id) {

--- a/src/main/java/roomescape/dao/ReservationJdbcDAO.java
+++ b/src/main/java/roomescape/dao/ReservationJdbcDAO.java
@@ -44,7 +44,7 @@ public class ReservationJdbcDAO implements ReservationDAO {
                     reservation.getTime());
 
         } catch (DataInvalidException e) {
-            throw new DataInvalidException(e.getMessage());
+            throw new DataInvalidException("데이터 저장 중 오류 발생: " + e.getMessage());
         }
 
     }

--- a/src/main/java/roomescape/dao/ReservationJdbcDAO.java
+++ b/src/main/java/roomescape/dao/ReservationJdbcDAO.java
@@ -65,23 +65,10 @@ public class ReservationJdbcDAO implements ReservationDAO {
             throw new DataInvalidException("예약을 찾을 수 없습니다. ID: " + id);
         }
     }
+    
 
     @Override
-    public int count() {
-        String sql = "SELECT COUNT(*) FROM reservation";
-        try {
-            Integer count = jdbcTemplate.queryForObject(sql, Integer.class);
-            if (count == null) {
-                return 0;
-            }
-            return count;
-        } catch (Exception e) {
-            throw new InvalidException("ID를 조회하는 동안 오류 발생 : " + e.getMessage());
-        }
-    }
-
-    @Override
-    public Reservation getById(int id) {
+    public Reservation getById(long id) {
         String sql = "SELECT * FROM reservation WHERE id = ?";
 
         try {

--- a/src/main/java/roomescape/dao/ReservationJdbcDAO.java
+++ b/src/main/java/roomescape/dao/ReservationJdbcDAO.java
@@ -1,32 +1,49 @@
 package roomescape.dao;
 
+import java.sql.PreparedStatement;
+import java.sql.Statement;
 import java.util.List;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 import roomescape.entity.Reservation;
-import roomescape.exception.InvalidException;
-import roomescape.exception.NotFoundReservationException;
+import roomescape.exception.DataInvalidException;
 
 
 @Repository
 public class ReservationJdbcDAO implements ReservationDAO {
 
     private final JdbcTemplate jdbcTemplate;
-    private final RowMapper<Reservation> rowMapper = new ReservationRowMapper(); //
+    private final RowMapper<Reservation> rowMapper = new ReservationRowMapper();
 
     public ReservationJdbcDAO(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
     }
 
     @Override
-    public void save(Reservation reservation) {
-        String sql = "INSERT INTO reservation (name, date, ime) VALUES (?, ?, ?)";
+    public Reservation save(Reservation reservation) {
+
+        String sql = "INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)";
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+
         try {
-            jdbcTemplate.update(sql, reservation.getName(), reservation.getDate(), reservation.getTime());
-        } catch (InvalidException e) {
-            throw new InvalidException(e.getMessage());
+            jdbcTemplate.update(connection -> {
+                PreparedStatement ps = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+                ps.setString(1, reservation.getName());
+                ps.setDate(2, java.sql.Date.valueOf(reservation.getDate()));
+                ps.setTime(3, java.sql.Time.valueOf(reservation.getTime()));
+                return ps;
+            }, keyHolder);
+
+            long generatedId = keyHolder.getKey().longValue();
+
+            return new Reservation(generatedId, reservation.getName(), reservation.getDate(), reservation.getTime());
+
+        } catch (DataInvalidException e) {
+            throw new DataInvalidException(e.getMessage());
         }
 
     }
@@ -37,15 +54,6 @@ public class ReservationJdbcDAO implements ReservationDAO {
         return jdbcTemplate.query(sql, rowMapper);
     }
 
-    @Override
-    public void update(Reservation reservation) {
-        String sql = "UPDATE reservation SET name = ? , date = ?, time = ? WHERE id = ? ";
-        int rowAffected = jdbcTemplate.update(sql, reservation.getName(), reservation.getDate(), reservation.getTime(),
-                reservation.getId());
-        if (rowAffected == 0) {
-            throw new InvalidException("예약을 찾을 수 없습니다.");
-        }
-    }
 
     @Override
     public void delete(long id) {
@@ -53,7 +61,7 @@ public class ReservationJdbcDAO implements ReservationDAO {
 
         int rowsAffected = jdbcTemplate.update(sql, id);
         if (rowsAffected == 0) {
-            throw new InvalidException("예약을 찾을 수 없습니다. ID: " + id);
+            throw new DataInvalidException("예약을 찾을 수 없습니다. ID: " + id);
         }
     }
 
@@ -78,7 +86,7 @@ public class ReservationJdbcDAO implements ReservationDAO {
         try {
             return jdbcTemplate.queryForObject(sql, rowMapper, id);
         } catch (EmptyResultDataAccessException e) {
-            throw new NotFoundReservationException("해당 ID의 예약을 찾을 수 없습니다 : " + e.getMessage());
+            throw new DataInvalidException("해당 ID의 예약을 찾을 수 없습니다 : " + e.getMessage());
         }
 
     }

--- a/src/main/java/roomescape/dao/ReservationJdbcDAO.java
+++ b/src/main/java/roomescape/dao/ReservationJdbcDAO.java
@@ -32,6 +32,7 @@ public class ReservationJdbcDAO implements ReservationDAO {
     public Reservation save(Reservation reservation) {
 
         try {
+
             Map<String, Object> parameters = new HashMap<>();
             parameters.put("name", reservation.getName());
             parameters.put("date", reservation.getDate());

--- a/src/main/java/roomescape/dao/ReservationJdbcDAO.java
+++ b/src/main/java/roomescape/dao/ReservationJdbcDAO.java
@@ -31,22 +31,15 @@ public class ReservationJdbcDAO implements ReservationDAO {
     @Override
     public Reservation create(Reservation reservation) {
 
-        try {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("name", reservation.getName());
+        parameters.put("date", reservation.getDate());
+        parameters.put("time", reservation.getTime());
 
-            Map<String, Object> parameters = new HashMap<>();
-            parameters.put("name", reservation.getName());
-            parameters.put("date", reservation.getDate());
-            parameters.put("time", reservation.getTime());
+        Number generatedId = simpleJdbcInsert.executeAndReturnKey(parameters);
 
-            Number generatedId = simpleJdbcInsert.executeAndReturnKey(parameters);
-
-            return new Reservation(generatedId.longValue(), reservation.getName(), reservation.getDate(),
-                    reservation.getTime());
-
-        } catch (DataInvalidException e) {
-            throw new DataInvalidException("데이터 저장 중 오류 발생: " + e.getMessage());
-        }
-
+        return new Reservation(generatedId.longValue(), reservation.getName(), reservation.getDate(),
+                reservation.getTime());
     }
 
     @Override

--- a/src/main/java/roomescape/dao/ReservationRowMapper.java
+++ b/src/main/java/roomescape/dao/ReservationRowMapper.java
@@ -6,13 +6,16 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 public class ReservationRowMapper implements RowMapper<Reservation> {
+
     @Override
     public Reservation mapRow(ResultSet rs, int rowNum) throws SQLException {
+
         return new Reservation(
                 rs.getInt("id"),
                 rs.getString("name"),
                 rs.getDate("date").toLocalDate(),
                 rs.getTime("time").toLocalTime()
         );
+
     }
 }

--- a/src/main/java/roomescape/entity/Reservation.java
+++ b/src/main/java/roomescape/entity/Reservation.java
@@ -27,7 +27,6 @@ public class Reservation {
         this.time = time;
     }
 
-
     private void validateName(String name) {
         if (name == null || name.isBlank()) {
             throw new InvalidException("Name is required");

--- a/src/main/java/roomescape/exception/DataInvalidException.java
+++ b/src/main/java/roomescape/exception/DataInvalidException.java
@@ -1,0 +1,7 @@
+package roomescape.exception;
+
+public class DataInvalidException extends RuntimeException {
+  public DataInvalidException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/roomescape/exception/DataInvalidException.java
+++ b/src/main/java/roomescape/exception/DataInvalidException.java
@@ -1,7 +1,12 @@
 package roomescape.exception;
 
-public class DataInvalidException extends RuntimeException {
-  public DataInvalidException(String message) {
-    super(message);
-  }
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.BAD_REQUEST, reason = "Bad Request")
+public class DataInvalidException extends DataAccessException {
+    public DataInvalidException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -1,7 +1,5 @@
 package roomescape.exception;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -21,6 +19,12 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> notFoundReservation(NotFoundReservationException ex) {
         ErrorResponse errorResponse = new ErrorResponse("Not Found", ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(DataInvalidException.class)
+    public ResponseEntity<ErrorResponse> dataInvalidException(DataInvalidException ex) {
+        ErrorResponse errorResponse = new ErrorResponse("Data Access Exception", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
 }

--- a/src/test/java/roomescape/JDBCMissionStepTest.java
+++ b/src/test/java/roomescape/JDBCMissionStepTest.java
@@ -25,14 +25,14 @@ import roomescape.entity.Reservation;
 public class JDBCMissionStepTest {
 
     @LocalServerPort
-    private int port; //랜덤 포트 값을 주입받음
+    private int port;
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
     @BeforeEach
     void setUp() {
-        RestAssured.port = port; //ResetAssured 가 테스트 포트의 랜덤 값 사용
+        RestAssured.port = port;
     }
 
     @Test

--- a/src/test/java/roomescape/JDBCMissionStepTest.java
+++ b/src/test/java/roomescape/JDBCMissionStepTest.java
@@ -3,9 +3,12 @@ package roomescape;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -49,4 +52,33 @@ public class JDBCMissionStepTest {
 
         assertThat(reservations.size()).isEqualTo(count);
     }
+
+    @Test
+    void 칠단계() {
+
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "2023-08-05");
+        params.put("time", "10:00");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(201)
+                .header("Location", "/reservations/1");
+
+        Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        assertThat(count).isEqualTo(1);
+
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(204);
+
+        Integer countAfterDelete = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        assertThat(countAfterDelete).isEqualTo(0);
+    }
+
 }

--- a/src/test/java/roomescape/JDBCMissionStepTest.java
+++ b/src/test/java/roomescape/JDBCMissionStepTest.java
@@ -9,22 +9,31 @@ import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import roomescape.entity.Reservation;
 
 
-@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class JDBCMissionStepTest {
 
+    @LocalServerPort
+    private int port; //랜덤 포트 값을 주입받음
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port; //ResetAssured 가 테스트 포트의 랜덤 값 사용
+    }
 
     @Test
     void 오단계() {

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -20,13 +20,12 @@ import org.springframework.test.annotation.DirtiesContext;
 public class MissionStepTest {
 
     @LocalServerPort
-    private int port; //랜덤 포트 값 주입
+    private int port;
 
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
     }
-
 
     @Test
     @DisplayName("일단계")

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -16,7 +16,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 
-@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
 

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -6,16 +6,27 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
 
 //RANDOM_PORT로 추후 적용 예정
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
+
+    @LocalServerPort
+    private int port; //랜덤 포트 값 주입
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
 
     @Test
     @DisplayName("일단계")

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -9,12 +9,13 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 
-//RANDOM_PORT로 추후 적용 예정
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
@@ -26,6 +27,10 @@ public class MissionStepTest {
     void setUp() {
         RestAssured.port = port;
     }
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
 
     @Test
     @DisplayName("일단계")
@@ -46,11 +51,20 @@ public class MissionStepTest {
                 .then().log().all()
                 .statusCode(200);
 
+        Integer initialCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM reservation", Integer.class);
+
+        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "사용자1", "2025-02-23",
+                "10:00");
+        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "사용자2", "2025-02-23",
+                "11:00");
+        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "사용자3", "2025-02-23",
+                "12:00");
+
         RestAssured.given().log().all()
                 .when().get("/reservations")
                 .then().log().all()
                 .statusCode(200)
-                .body("size()", is(3));
+                .body("size()", is(initialCount + 3));
     }
 
     @Test

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -26,6 +26,7 @@ public class MissionStepTest {
                 .statusCode(200);
     }
 
+    //임의의 List에 넣어준 갯수를 확인했던 테스트 코드이기 때문에 7단계 시점에서는 통과하지 않습니다.
     @Test
     @DisplayName("이단계")
     void 이단계() {
@@ -39,7 +40,7 @@ public class MissionStepTest {
                 .when().get("/reservations")
                 .then().log().all()
                 .statusCode(200)
-                .body("size()", is(3)); // 아직 생성 요청이 없으니 Controller에서 임의로 넣어준 Reservation 갯수 만큼 검증하거나 0개임을 확인하세요.
+                .body("size()", is(3));
     }
 
     @Test


### PR DESCRIPTION
안녕하세요 트레님 :)

한꺼번에 코드를 다 수정해놓고 커밋을 해서 클래스 단위로 커밋을 하게 되었네요.
(cherry-pick 을 하면서 커밋 단위를 직접적으로 느껴본지라 많은 반성을 합니다...)

기능 구현 단위로 해보려고 노력했는데, 아직 많이 부족하지만 계속 발전시켜 나가겠습니다.
아래는 피드백 주신 부분에서 고민하고 적용시켜본 부분인데요.

**1. RANDOM_PORT와 DEFINE_PORT의 차이, 그리고 테스트 적용** 

RestAssured 의 설정 중

```java
 public static final int DEFAULT_PORT = 8080;
```

 를 보고 랜덤으로 포트 번호가 설정되어도 테스트 코드가 포트번호를 모른다면 서버를 찾지 못해 실패하는 것 같아
(그렇기에 RANDOM_PORT 할당시 서버를 실행해야 했었음)
테스트 코드에 포트 번호를 할당해주는 LocalServerPort 를 할당하는 방법에 대해 찾아봤습니다.
 
``` 
  1. 랜덤 포트에서 생성된 포트 번호가 테스트 실행 전에 할당
  2. Spring이 할당된 포트 번호를 @LocalServerPort가 붙은 필드에 자동으로 주입
  3. 테스트 코드 실행 전(@BeforeEach)에 포트 적용
```

공식 문서에 들어가도 사실 LocalServerPort에 대한 설명이 자세하지 않아서 작동 원리에 대해 좀 더 찾아봤는데 해당 어노테이션을 적용시키고 포트번호를 할당하니 어플리케이션 실행없이도 테스트가 되는 걸 확인할 수 있었습니다.

**2. 커스텀 예외 처리시,  발생한 예외 메시지를 노출시키지 않고 처리하는 법**

dataAccessException 을 처리할때 예외 메세지를 클라이언트에 노출시킨다면 보안상 좋지 않다는 말씀을 해주셨는데, 
이 경우 String으로만 예외 메세지를 클라이언트에게 보내는지, 아니면 세부 내역인 e.getMessage까지 포함시켜야하는지.. 의 기준을 잡지 못해 String 으로만 save 메서드의 예외처리를 진행해두었습니다. 