### PR TITLE
[ Spring MVC ] 박채연 미션 제출 합니다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 test {

--- a/src/main/java/roomescape/controller/HomeController.java
+++ b/src/main/java/roomescape/controller/HomeController.java
@@ -1,0 +1,12 @@
+package roomescape.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+    @GetMapping("/")
+    public String home() {
+        return "home";
+    }
+}

--- a/src/main/java/roomescape/controller/HomeController.java
+++ b/src/main/java/roomescape/controller/HomeController.java
@@ -5,8 +5,10 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class HomeController {
+    private static final String VIEW_HOME = "home";
+
     @GetMapping("/")
     public String home() {
-        return "home";
+        return VIEW_HOME;
     }
 }

--- a/src/main/java/roomescape/controller/ReservationApiController.java
+++ b/src/main/java/roomescape/controller/ReservationApiController.java
@@ -17,49 +17,32 @@ import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
 import roomescape.exception.status.ReservationNotFoundException;
+import roomescape.service.ReservationService;
 
 @RestController
 @RequestMapping("/reservations")
 public class ReservationApiController {
-    private final List<Reservation> reservations = new ArrayList<>();
-    private final AtomicLong index = new AtomicLong(1);
 
-    @PostMapping()
-    public ResponseEntity<ReservationResponse> createReservation(
-            @Valid @RequestBody ReservationRequest reservationRequest) {
-        Reservation reservation = Reservation.of(
-                index.getAndIncrement(),
-                reservationRequest.getName(),
-                reservationRequest.getDate(),
-                reservationRequest.getTime()
-        );
-        reservations.add(reservation);
+    private final ReservationService reservationService;
 
-        ReservationResponse reservationResponse = new ReservationResponse(
-                reservation.getId(),
-                reservation.getName(),
-                reservation.getDate(),
-                reservation.getTime()
-        );
-
-        return ResponseEntity
-                .created(URI.create("/reservations/" + reservation.getId()))
-                .body(reservationResponse);
+    public ReservationApiController(ReservationService reservationService) {
+        this.reservationService = reservationService;
     }
 
-    @GetMapping()
+    @PostMapping
+    public ResponseEntity<ReservationResponse> createReservation(@Valid @RequestBody ReservationRequest request) {
+        ReservationResponse response = reservationService.create(request);
+        return ResponseEntity.created(URI.create("/reservations/" + response.getId())).body(response);
+    }
+
+    @GetMapping
     public List<ReservationResponse> getReservations() {
-        return reservations.stream().map(r -> new ReservationResponse(r.getId(), r.getName(), r.getDate(), r.getTime()))
-                .toList();
+        return reservationService.findAll();
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteReservation(@PathVariable long id) {
-        boolean removed = reservations.removeIf(r -> r.getId() == id);
-        if (!removed) {
-            throw new ReservationNotFoundException(id);
-        }
+    public ResponseEntity<Void> deleteReservation(@PathVariable Long id) {
+        reservationService.deleteById(id);
         return ResponseEntity.noContent().build();
     }
-
 }

--- a/src/main/java/roomescape/controller/ReservationApiController.java
+++ b/src/main/java/roomescape/controller/ReservationApiController.java
@@ -5,7 +5,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -45,4 +47,11 @@ public class ReservationApiController {
         return reservations.stream().map(r -> new ReservationResponse(r.getId(), r.getName(), r.getDate(), r.getTime()))
                 .toList();
     }
+
+    @DeleteMapping("/reservations/{id}")
+    public ResponseEntity<Void> deleteReservation(@PathVariable long id) {
+        reservations.removeIf(r -> r.getId() == id);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/roomescape/controller/ReservationApiController.java
+++ b/src/main/java/roomescape/controller/ReservationApiController.java
@@ -13,10 +13,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
-import roomescape.exception.status.ReservationNotFoundException;
 import roomescape.service.ReservationService;
 
 @RestController

--- a/src/main/java/roomescape/controller/ReservationApiController.java
+++ b/src/main/java/roomescape/controller/ReservationApiController.java
@@ -1,18 +1,48 @@
 package roomescape.controller;
 
+import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.domain.Reservation;
+import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
 
 @RestController
 public class ReservationApiController {
+    private final List<Reservation> reservations = new ArrayList<>();
+    private final AtomicLong index = new AtomicLong(1);
+
+    @PostMapping("/reservations")
+    public ResponseEntity<ReservationResponse> createReservation(@RequestBody ReservationRequest reservationRequest) {
+        Reservation reservation = new Reservation(
+                index.getAndIncrement(),
+                reservationRequest.getName(),
+                reservationRequest.getDate(),
+                reservationRequest.getTime()
+        );
+        reservations.add(reservation);
+
+        ReservationResponse reservationResponse = new ReservationResponse(
+                reservation.getId(),
+                reservation.getName(),
+                reservation.getDate(),
+                reservation.getTime()
+        );
+
+        return ResponseEntity
+                .created(URI.create("/reservations/" + reservation.getId()))
+                .body(reservationResponse);
+    }
+
     @GetMapping("/reservations")
     public List<ReservationResponse> getReservations() {
-        return List.of(
-                new ReservationResponse(1L, "햄버거", "2025-06-17", "10:00"),
-                new ReservationResponse(2L, "감자튀김", "2025-06-17", "11:00"),
-                new ReservationResponse(3L, "콜라", "2025-06-17", "12:00")
-        );
+        return reservations.stream().map(r -> new ReservationResponse(r.getId(), r.getName(), r.getDate(), r.getTime()))
+                .toList();
     }
 }

--- a/src/main/java/roomescape/controller/ReservationApiController.java
+++ b/src/main/java/roomescape/controller/ReservationApiController.java
@@ -1,0 +1,18 @@
+package roomescape.controller;
+
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import roomescape.dto.ReservationResponse;
+
+@RestController
+public class ReservationApiController {
+    @GetMapping("/reservations")
+    public List<ReservationResponse> getReservations() {
+        return List.of(
+                new ReservationResponse(1L, "햄버거", "2025-06-17", "10:00"),
+                new ReservationResponse(2L, "감자튀김", "2025-06-17", "11:00"),
+                new ReservationResponse(3L, "콜라", "2025-06-17", "12:00")
+        );
+    }
+}

--- a/src/main/java/roomescape/controller/ReservationApiController.java
+++ b/src/main/java/roomescape/controller/ReservationApiController.java
@@ -22,7 +22,7 @@ public class ReservationApiController {
 
     @PostMapping("/reservations")
     public ResponseEntity<ReservationResponse> createReservation(@RequestBody ReservationRequest reservationRequest) {
-        Reservation reservation = new Reservation(
+        Reservation reservation = Reservation.of(
                 index.getAndIncrement(),
                 reservationRequest.getName(),
                 reservationRequest.getDate(),

--- a/src/main/java/roomescape/controller/ReservationApiController.java
+++ b/src/main/java/roomescape/controller/ReservationApiController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequest;
@@ -18,11 +19,12 @@ import roomescape.dto.ReservationResponse;
 import roomescape.exception.status.ReservationNotFoundException;
 
 @RestController
+@RequestMapping("/reservations")
 public class ReservationApiController {
     private final List<Reservation> reservations = new ArrayList<>();
     private final AtomicLong index = new AtomicLong(1);
 
-    @PostMapping("/reservations")
+    @PostMapping()
     public ResponseEntity<ReservationResponse> createReservation(
             @Valid @RequestBody ReservationRequest reservationRequest) {
         Reservation reservation = Reservation.of(
@@ -45,13 +47,13 @@ public class ReservationApiController {
                 .body(reservationResponse);
     }
 
-    @GetMapping("/reservations")
+    @GetMapping()
     public List<ReservationResponse> getReservations() {
         return reservations.stream().map(r -> new ReservationResponse(r.getId(), r.getName(), r.getDate(), r.getTime()))
                 .toList();
     }
 
-    @DeleteMapping("/reservations/{id}")
+    @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteReservation(@PathVariable long id) {
         boolean removed = reservations.removeIf(r -> r.getId() == id);
         if (!removed) {

--- a/src/main/java/roomescape/controller/ReservationApiController.java
+++ b/src/main/java/roomescape/controller/ReservationApiController.java
@@ -1,5 +1,6 @@
 package roomescape.controller;
 
+import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
+import roomescape.exception.status.ReservationNotFoundException;
 
 @RestController
 public class ReservationApiController {
@@ -21,7 +23,8 @@ public class ReservationApiController {
     private final AtomicLong index = new AtomicLong(1);
 
     @PostMapping("/reservations")
-    public ResponseEntity<ReservationResponse> createReservation(@RequestBody ReservationRequest reservationRequest) {
+    public ResponseEntity<ReservationResponse> createReservation(
+            @Valid @RequestBody ReservationRequest reservationRequest) {
         Reservation reservation = Reservation.of(
                 index.getAndIncrement(),
                 reservationRequest.getName(),
@@ -50,7 +53,10 @@ public class ReservationApiController {
 
     @DeleteMapping("/reservations/{id}")
     public ResponseEntity<Void> deleteReservation(@PathVariable long id) {
-        reservations.removeIf(r -> r.getId() == id);
+        boolean removed = reservations.removeIf(r -> r.getId() == id);
+        if (!removed) {
+            throw new ReservationNotFoundException(id);
+        }
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -1,0 +1,13 @@
+package roomescape.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Controller
+public class ReservationController {
+    @GetMapping("/reservation")
+    public String reservation() {
+        return "reservation";
+    }
+}

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -6,8 +6,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 @Controller
 public class ReservationController {
+    private static final String VIEW_RESERVATION = "reservation";
+
     @GetMapping("/reservation")
     public String reservation() {
-        return "reservation";
+        return VIEW_RESERVATION;
     }
 }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -2,7 +2,6 @@ package roomescape.controller;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
 @Controller
 public class ReservationController {

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -1,0 +1,33 @@
+package roomescape.domain;
+
+public class Reservation {
+    private Long id;
+    private String name;
+    private String date;
+    private String time;
+
+    public Reservation(Long id, String name, String date, String time) {
+        this.id = id;
+        this.name = name;
+        this.date = date;
+        this.time = time;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public String getTime() {
+        return time;
+    }
+
+}
+

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -1,12 +1,15 @@
 package roomescape.domain;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 public class Reservation {
     private final Long id;
     private final String name;
-    private final String date;
-    private final String time;
+    private final LocalDate date;
+    private final LocalTime time;
 
-    private Reservation(Long id, String name, String date, String time) {
+    private Reservation(Long id, String name, LocalDate date, LocalTime time) {
         validate(name, date, time);
         this.id = id;
         this.name = name;
@@ -14,37 +17,21 @@ public class Reservation {
         this.time = time;
     }
 
-    public static Reservation of(Long id, String name, String date, String time) {
+    public static Reservation of(Long id, String name,  LocalDate date, LocalTime time) {
         return new Reservation(id, name, date, time);
     }
 
-    private void validate(String name, String date, String time) {
+    private void validate(String name, LocalDate date, LocalTime time) {
         if (name == null || name.isBlank()) {
             throw new IllegalArgumentException("이름은 필수입니다.");
         }
-        if (!date.matches("\\d{4}-\\d{2}-\\d{2}")) {
-            throw new IllegalArgumentException("날짜 형식은 yyyy-MM-dd 이어야 합니다.");
-        }
-        if (!time.matches("\\d{2}:\\d{2}")) {
-            throw new IllegalArgumentException("시간 형식은 HH:mm 이어야 합니다.");
+        if (date == null || time == null) {
+            throw new IllegalArgumentException("날짜 및 시간은 필수입니다.");
         }
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getDate() {
-        return date;
-    }
-
-    public String getTime() {
-        return time;
-    }
-
+    public Long getId() { return id; }
+    public String getName() { return name; }
+    public LocalDate getDate() { return date; }
+    public LocalTime getTime() { return time; }
 }
-

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -1,16 +1,33 @@
 package roomescape.domain;
 
 public class Reservation {
-    private Long id;
-    private String name;
-    private String date;
-    private String time;
+    private final Long id;
+    private final String name;
+    private final String date;
+    private final String time;
 
-    public Reservation(Long id, String name, String date, String time) {
+    private Reservation(Long id, String name, String date, String time) {
+        validate(name, date, time);
         this.id = id;
         this.name = name;
         this.date = date;
         this.time = time;
+    }
+
+    public static Reservation of(Long id, String name, String date, String time) {
+        return new Reservation(id, name, date, time);
+    }
+
+    private void validate(String name, String date, String time) {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("이름은 필수입니다.");
+        }
+        if (!date.matches("\\d{4}-\\d{2}-\\d{2}")) {
+            throw new IllegalArgumentException("날짜 형식은 yyyy-MM-dd 이어야 합니다.");
+        }
+        if (!time.matches("\\d{2}:\\d{2}")) {
+            throw new IllegalArgumentException("시간 형식은 HH:mm 이어야 합니다.");
+        }
     }
 
     public Long getId() {

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -2,6 +2,9 @@ package roomescape.domain;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import roomescape.exception.status.InvalidReservationException;
 
 public class Reservation {
     private final Long id;
@@ -17,21 +20,41 @@ public class Reservation {
         this.time = time;
     }
 
-    public static Reservation of(Long id, String name,  LocalDate date, LocalTime time) {
+    public static Reservation of(Long id, String name, LocalDate date, LocalTime time) {
         return new Reservation(id, name, date, time);
     }
 
     private void validate(String name, LocalDate date, LocalTime time) {
+        List<String> errors = new ArrayList<>();
+
         if (name == null || name.isBlank()) {
-            throw new IllegalArgumentException("이름은 필수입니다.");
+            errors.add("이름은 필수입니다.");
         }
-        if (date == null || time == null) {
-            throw new IllegalArgumentException("날짜 및 시간은 필수입니다.");
+        if (date == null) {
+            errors.add("날짜는 필수입니다.");
+        }
+        if (time == null) {
+            errors.add("시간은 필수입니다.");
+        }
+
+        if (!errors.isEmpty()) {
+            throw new InvalidReservationException(errors);
         }
     }
 
-    public Long getId() { return id; }
-    public String getName() { return name; }
-    public LocalDate getDate() { return date; }
-    public LocalTime getTime() { return time; }
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public LocalTime getTime() {
+        return time;
+    }
 }

--- a/src/main/java/roomescape/dto/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/ReservationRequest.java
@@ -1,0 +1,19 @@
+package roomescape.dto;
+
+public class ReservationRequest {
+    private String name;
+    private String date;
+    private String time;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public String getTime() {
+        return time;
+    }
+}

--- a/src/main/java/roomescape/dto/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/ReservationRequest.java
@@ -1,8 +1,15 @@
 package roomescape.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public class ReservationRequest {
+    @NotBlank(message = "이름은 필수입니다.")
     private String name;
+
+    @NotBlank(message = "날짜는 필수입니다.")
     private String date;
+
+    @NotBlank(message = "시간은 필수입니다.")
     private String time;
 
     public String getName() {

--- a/src/main/java/roomescape/dto/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/ReservationRequest.java
@@ -22,12 +22,6 @@ public class ReservationRequest {
 
     protected ReservationRequest() {}
 
-    public ReservationRequest(String name, LocalDate date, LocalTime time) {
-        this.name = name;
-        this.date = date;
-        this.time = time;
-    }
-
     public String getName() {
         return name;
     }

--- a/src/main/java/roomescape/dto/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/ReservationRequest.java
@@ -1,26 +1,43 @@
 package roomescape.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
 
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 public class ReservationRequest {
-    @NotBlank(message = "이름은 필수입니다.")
+
+    @NotBlank
     private String name;
 
-    @NotBlank(message = "날짜는 필수입니다.")
-    private String date;
+    @NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
 
-    @NotBlank(message = "시간은 필수입니다.")
-    private String time;
+    @NotNull
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime time;
+
+    protected ReservationRequest() {}
+
+    public ReservationRequest(String name, LocalDate date, LocalTime time) {
+        this.name = name;
+        this.date = date;
+        this.time = time;
+    }
 
     public String getName() {
         return name;
     }
 
-    public String getDate() {
+    public LocalDate getDate() {
         return date;
     }
 
-    public String getTime() {
+    public LocalTime getTime() {
         return time;
     }
 }
+

--- a/src/main/java/roomescape/dto/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/ReservationRequest.java
@@ -20,7 +20,8 @@ public class ReservationRequest {
     @JsonFormat(pattern = "HH:mm")
     private LocalTime time;
 
-    protected ReservationRequest() {}
+    protected ReservationRequest() {
+    }
 
     public String getName() {
         return name;

--- a/src/main/java/roomescape/dto/ReservationResponse.java
+++ b/src/main/java/roomescape/dto/ReservationResponse.java
@@ -1,0 +1,15 @@
+package roomescape.dto;
+
+public class ReservationResponse {
+    private Long id;
+    private String name;
+    private String date;
+    private String time;
+
+    public ReservationResponse(Long id, String name, String date, String time) {
+        this.id = id;
+        this.name = name;
+        this.date = date;
+        this.time = time;
+    }
+}

--- a/src/main/java/roomescape/dto/ReservationResponse.java
+++ b/src/main/java/roomescape/dto/ReservationResponse.java
@@ -12,4 +12,20 @@ public class ReservationResponse {
         this.date = date;
         this.time = time;
     }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public String getTime() {
+        return time;
+    }
 }

--- a/src/main/java/roomescape/dto/ReservationResponse.java
+++ b/src/main/java/roomescape/dto/ReservationResponse.java
@@ -3,6 +3,7 @@ package roomescape.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import roomescape.domain.Reservation;
 
 public class ReservationResponse {
 
@@ -15,11 +16,11 @@ public class ReservationResponse {
     @JsonFormat(pattern = "HH:mm")
     private LocalTime time;
 
-    public ReservationResponse(Long id, String name, LocalDate date, LocalTime time) {
-        this.id = id;
-        this.name = name;
-        this.date = date;
-        this.time = time;
+    public ReservationResponse(Reservation reservation) {
+        this.id = reservation.getId();
+        this.name = reservation.getName();
+        this.date = reservation.getDate();
+        this.time = reservation.getTime();
     }
 
     public Long getId() {

--- a/src/main/java/roomescape/dto/ReservationResponse.java
+++ b/src/main/java/roomescape/dto/ReservationResponse.java
@@ -1,12 +1,21 @@
 package roomescape.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
 public class ReservationResponse {
+
     private Long id;
     private String name;
-    private String date;
-    private String time;
 
-    public ReservationResponse(Long id, String name, String date, String time) {
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    @JsonFormat(pattern = "HH:mm")
+    private LocalTime time;
+
+    public ReservationResponse(Long id, String name, LocalDate date, LocalTime time) {
         this.id = id;
         this.name = name;
         this.date = date;
@@ -21,11 +30,11 @@ public class ReservationResponse {
         return name;
     }
 
-    public String getDate() {
+    public LocalDate getDate() {
         return date;
     }
 
-    public String getTime() {
+    public LocalTime getTime() {
         return time;
     }
 }

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -10,6 +10,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ReservationNotFoundException.class)
     public ResponseEntity<String> handleReservationNotFound(ReservationNotFoundException e) {
-        return ResponseEntity.badRequest().body(e.getMessage());
+        return ResponseEntity.status(400).body(e.getMessage());
     }
 }

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -11,7 +11,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ReservationNotFoundException.class)
     public ResponseEntity<String> handleReservationNotFound(ReservationNotFoundException e) {
-        return ResponseEntity.status(400).body(e.getMessage());
+        return ResponseEntity.status(404).body(e.getMessage());
     }
 
     @ExceptionHandler(InvalidReservationException.class)

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package roomescape.exception;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import roomescape.exception.status.InvalidReservationException;
 import roomescape.exception.status.ReservationNotFoundException;
 
 @RestControllerAdvice
@@ -12,4 +13,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleReservationNotFound(ReservationNotFoundException e) {
         return ResponseEntity.status(400).body(e.getMessage());
     }
+
+    @ExceptionHandler(InvalidReservationException.class)
+    public ResponseEntity<String> handleInvalidReservation(InvalidReservationException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+
 }

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package roomescape.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import roomescape.exception.status.ReservationNotFoundException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ReservationNotFoundException.class)
+    public ResponseEntity<String> handleReservationNotFound(ReservationNotFoundException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+}

--- a/src/main/java/roomescape/exception/status/InvalidReservationException.java
+++ b/src/main/java/roomescape/exception/status/InvalidReservationException.java
@@ -1,0 +1,16 @@
+package roomescape.exception.status;
+
+import java.util.List;
+
+public class InvalidReservationException extends RuntimeException {
+    private final List<String> messages;
+
+    public InvalidReservationException(List<String> messages) {
+        super(String.join(", ", messages));
+        this.messages = messages;
+    }
+
+    public List<String> getMessages() {
+        return messages;
+    }
+}

--- a/src/main/java/roomescape/exception/status/ReservationNotFoundException.java
+++ b/src/main/java/roomescape/exception/status/ReservationNotFoundException.java
@@ -1,0 +1,7 @@
+package roomescape.exception.status;
+
+public class ReservationNotFoundException extends RuntimeException {
+    public ReservationNotFoundException(Long id) {
+        super("예약을 찾을 수 없습니다. id=" + id);
+    }
+}

--- a/src/main/java/roomescape/exception/validation/MethodArgumentNotValidExceptionHandler.java
+++ b/src/main/java/roomescape/exception/validation/MethodArgumentNotValidExceptionHandler.java
@@ -1,0 +1,16 @@
+package roomescape.exception.validation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class MethodArgumentNotValidExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handle(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity.badRequest().body(message);
+    }
+}

--- a/src/main/java/roomescape/exception/validation/MethodArgumentNotValidExceptionHandler.java
+++ b/src/main/java/roomescape/exception/validation/MethodArgumentNotValidExceptionHandler.java
@@ -1,6 +1,9 @@
 package roomescape.exception.validation;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -9,8 +12,11 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class MethodArgumentNotValidExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<String> handle(MethodArgumentNotValidException e) {
-        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
-        return ResponseEntity.badRequest().body(message);
+    public ResponseEntity<List<String>> handle(MethodArgumentNotValidException e) {
+        List<String> messages = e.getBindingResult().getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.badRequest().body(messages);
     }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -1,0 +1,33 @@
+package roomescape.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Service;
+import roomescape.domain.Reservation;
+import roomescape.dto.ReservationRequest;
+import roomescape.dto.ReservationResponse;
+import roomescape.exception.status.ReservationNotFoundException;
+
+@Service
+public class ReservationService {
+    private final List<Reservation> reservations = new ArrayList<>();
+    private final AtomicLong index = new AtomicLong(1);
+
+    public ReservationResponse create(ReservationRequest request) {
+        Reservation reservation = Reservation.of(index.getAndIncrement(), request.getName(), request.getDate(), request.getTime());
+        reservations.add(reservation);
+        return new ReservationResponse(reservation);
+    }
+
+    public List<ReservationResponse> findAll() {
+        return reservations.stream().map(ReservationResponse::new).toList();
+    }
+
+    public void deleteById(Long id) {
+        boolean removed = reservations.removeIf(r -> r.getId().equals(id));
+        if (!removed) throw new ReservationNotFoundException(id);
+    }
+}
+

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -33,7 +33,7 @@ public class MissionStepTest {
                 .when().get("/reservations")
                 .then().log().all()
                 .statusCode(200)
-                .body("size()", is(3)); // 아직 생성 요청이 없으니 Controller에서 임의로 넣어준 Reservation 갯수 만큼 검증하거나 0개임을 확인하세요.
+                .body("size()", is(0)); // 아직 생성 요청이 없으니 Controller에서 임의로 넣어준 Reservation 갯수 만큼 검증하거나 0개임을 확인하세요.
     }
 
     @Test

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+import static org.hamcrest.Matchers.is;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -15,5 +16,19 @@ public class MissionStepTest {
                 .when().get("/")
                 .then().log().all()
                 .statusCode(200);
+    }
+
+    @Test
+    void 이단계() {
+        RestAssured.given().log().all()
+                .when().get("/reservation")
+                .then().log().all()
+                .statusCode(200);
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(3)); // 아직 생성 요청이 없으니 Controller에서 임의로 넣어준 Reservation 갯수 만큼 검증하거나 0개임을 확인하세요.
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -1,9 +1,13 @@
 package roomescape;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+
 import static org.hamcrest.Matchers.is;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -30,5 +34,28 @@ public class MissionStepTest {
                 .then().log().all()
                 .statusCode(200)
                 .body("size()", is(3)); // 아직 생성 요청이 없으니 Controller에서 임의로 넣어준 Reservation 갯수 만큼 검증하거나 0개임을 확인하세요.
+    }
+
+    @Test
+    void 삼단계() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "2023-08-05");
+        params.put("time", "15:40");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(201)
+                .header("Location", "/reservations/1")
+                .body("id", is(1));
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(1));
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -70,4 +70,27 @@ public class MissionStepTest {
                 .body("size()", is(0));
     }
 
+    @Test
+    void 사단계() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "");
+        params.put("time", "");
+
+        // 필요한 인자가 없는 경우
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(400);
+
+        // 삭제할 예약이 없는 경우
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(400);
+    }
+
+
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -89,7 +89,7 @@ public class MissionStepTest {
         RestAssured.given().log().all()
                 .when().delete("/reservations/1")
                 .then().log().all()
-                .statusCode(400);
+                .statusCode(404);
     }
 
 

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -68,5 +68,6 @@ public class MissionStepTest {
                 .then().log().all()
                 .statusCode(200)
                 .body("size()", is(0));
-}
+    }
+
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -57,5 +57,16 @@ public class MissionStepTest {
                 .then().log().all()
                 .statusCode(200)
                 .body("size()", is(1));
-    }
+
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(204);
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(0));
+}
 }


### PR DESCRIPTION
안녕하세요  오랜만에 리뷰 요청 남깁니다!! 😊
### 리뷰 후 회고입니다.
- 클라이언트의 형식적 오류(입력값 미입력 등)를 컨트롤러 단계에서 차단하여 리소스 낭비를 최소화하였습니다.

- 도메인 객체 내부에서도 InvalidReservationException이라는 사용자 정의 예외를 활용해 필드 검증을 해주었습니다.
예외 메시지가 여러 개인 경우 List<String>으로 수집하고 순회하여 메시지로 전달했습니다.

- 예외 처리는 목적별로 분리했습니다.
> 1. 도메인 예외 ( 리소스, 비즈니스 로직 )
> 2. 스프링 내부 유효성 예외 ( @Valid, @NotNull )

- DB 연결이 없기 때문에 Service나 Repository 계층이 필요 없다고 생각했지만, Controller의 비즈니스 로직을 분리하기 위해 Service계층을 추가했습니다.

- 날짜, 시간 관련 타입을 사용했습니다.

---
### 미션을 수행하며 배운 것들 입니다.
1. Application에서 Controller.run( )하지 않아도 작동하는 이유?
@SpringBootApplication 구성 요소인 @ComponentScan 덕분
같은 패키지 및 하위 패키지를 자동 스캔해서 @Controller가 붙은 클래스를 자동으로 등록해준다. 

2. 2단계에서 DTO에 getter가 있어야 테스트 코드가 통과하는 이유?
Jackson은 Java 객체를 JSON으로 바꾸는 직렬화 라이브러리
직렬화를 하려면 객체 내부의 데이터를 꺼낼 수 있는 방법이 필요
Java 객체에서 데이터를 꺼내는 표준 방법이 바로 getter , 이게 없다면 500 에러

3. ResponseEntity 사용하는 이유?
POST와 DELETE 요청은 응답 상태 코드와 헤더를 명확히 제어해야 하므로, GET와는 다르게 
단순 데이터 반환보다 더 유연한 응답 구성이 가능한 ResponseEntity를 사용한다.

4. Post 로 추가한 예약정보는 어디에 저장?
Heap 메모리 안에 있는 List<Reservation> 객체에 저장되고, 동적 할당된 값들은 서버가 종료되면 사라진다.

---
 ### 고민한 부분들입니다.
- 도메인 객체의 필드 유효성 검사는 어떻게 구현할지 ?

도메인 객체인 Reservation의 생성자를 private으로 감추고, 대신 정적 팩토리 메서드 of()을 사용했다.

찾아보니, Spring에서 의존성 주입 대상이 되는 클래스(@Service, @Repository, @Controller 등)는 생성자 주입을 통해 관리되므로, 이 경우에는 정적 팩토리 메서드보다 생성자 내부 또는 별도 유효성 처리 방식을 사용하는 것이 일반적이라는 것을 알게 되었다.

- 예외 처리 패키지 구조 ?
#### validation 패키지 - 핸들러 정의
클라이언트의 형식적 오류 ( 예약 추가 시 필요한 인자값이 비어있는 경우 )로 인한 예외는 @Valid 어노테이션을 사용해 DTO 내부에 붙은 제약 조건을 검사해주었고, 실패시 자동으로 이미 정의된 MethodArgumentNotValidException을 던져 이를 사용자 정의 예외 클래스 내 @ExceptionHandler로 잡아서 처리해주었다.

#### status 패키지 - 사용자 정의 예외 클래스들 정의
요청 형식은 맞지만, 리소스를 찾을 수 없을 때 발생하므로, 비즈니스 로직 검증을 거친 뒤 발생하는 예외는 
@Valid 를 사용할 수 없고 직접 커스텀 예외를 만들어서 비즈니스 로직에서 throw 해야 한다. throw 한 예외는 핸들러가 받아서 처리한다.