### PR TITLE
[5, 6, 7단계 - Spring JDBC] 이지윤 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
+    runtimeOnly 'com.h2database:h2'
 }
 
 test {

--- a/src/main/java/roomescape/dao/ReservationDao.java
+++ b/src/main/java/roomescape/dao/ReservationDao.java
@@ -17,6 +17,12 @@ public class ReservationDao {
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     private final SimpleJdbcInsert jdbcInsert;
+    private final RowMapper<Reservation> rowMapper = (resultSet, rowNum) -> new Reservation(
+            resultSet.getLong("id"),
+            resultSet.getString("name"),
+            resultSet.getDate("date").toLocalDate(),
+            resultSet.getTime("time").toLocalTime()
+    );
 
     public ReservationDao(final DataSource dataSource) {
         this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
@@ -24,13 +30,6 @@ public class ReservationDao {
                 .withTableName("reservation")
                 .usingGeneratedKeyColumns("id");
     }
-
-    public final RowMapper<Reservation> rowMapper = (resultSet, rowNum) -> new Reservation(
-            resultSet.getLong("id"),
-            resultSet.getString("name"),
-            resultSet.getDate("date").toLocalDate(),
-            resultSet.getTime("time").toLocalTime()
-    );
 
     public Reservation save(final RequestReservation requestReservation) {
         Map<String, Object> parameters = new HashMap<>();

--- a/src/main/java/roomescape/dao/ReservationDao.java
+++ b/src/main/java/roomescape/dao/ReservationDao.java
@@ -1,0 +1,29 @@
+package roomescape.dao;
+
+import java.util.List;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import roomescape.domain.Reservation;
+
+@Repository
+public class ReservationDao {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ReservationDao(final JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public final RowMapper<Reservation> rowMapper = (resultSet, rowNum) -> new Reservation(
+            resultSet.getLong("id"),
+            resultSet.getString("name"),
+            resultSet.getDate("date").toLocalDate(),
+            resultSet.getTime("time").toLocalTime()
+    );
+
+    public List<Reservation> findAllReservation() {
+        String sql = "select id, name, date, time from reservation";
+        return jdbcTemplate.query(sql, rowMapper);
+    }
+}

--- a/src/main/java/roomescape/dao/ReservationDao.java
+++ b/src/main/java/roomescape/dao/ReservationDao.java
@@ -1,18 +1,28 @@
 package roomescape.dao;
 
+import java.util.HashMap;
 import java.util.List;
-import org.springframework.jdbc.core.JdbcTemplate;
+import java.util.Map;
+import java.util.Optional;
+import javax.sql.DataSource;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
+import roomescape.controller.dto.RequestReservation;
 import roomescape.domain.Reservation;
 
 @Repository
 public class ReservationDao {
 
-    private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private final SimpleJdbcInsert jdbcInsert;
 
-    public ReservationDao(final JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
+    public ReservationDao(final DataSource dataSource) {
+        this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
+        this.jdbcInsert = new SimpleJdbcInsert(dataSource)
+                .withTableName("reservation")
+                .usingGeneratedKeyColumns("id");
     }
 
     public final RowMapper<Reservation> rowMapper = (resultSet, rowNum) -> new Reservation(
@@ -22,8 +32,37 @@ public class ReservationDao {
             resultSet.getTime("time").toLocalTime()
     );
 
-    public List<Reservation> findAllReservation() {
-        String sql = "select id, name, date, time from reservation";
-        return jdbcTemplate.query(sql, rowMapper);
+    public Reservation save(final RequestReservation requestReservation) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("name", requestReservation.name());
+        parameters.put("date", requestReservation.parseDate());
+        parameters.put("time", requestReservation.parseTime());
+
+        Number newId = jdbcInsert.executeAndReturnKey(parameters);
+
+        return new Reservation(
+                newId.longValue(),
+                requestReservation.name(),
+                requestReservation.parseDate(),
+                requestReservation.parseTime()
+        );
+    }
+
+    public List<Reservation> findAll() {
+        String sql = "SELECT id, name, date, time FROM reservation";
+        return namedParameterJdbcTemplate.query(sql, rowMapper);
+    }
+
+    public Optional<Reservation> findById(final long id) {
+        String sql = "SELECT id, name, date, time FROM reservation WHERE id = :id";
+        Map<String, Object> params = Map.of("id", id);
+        List<Reservation> results = namedParameterJdbcTemplate.query(sql, params, rowMapper);
+        return results.stream().findFirst();
+    }
+
+    public void deleteById(final long id) {
+        String sql = "DELETE FROM reservation WHERE id = :id";
+        Map<String, Object> params = Map.of("id", id);
+        namedParameterJdbcTemplate.update(sql, params);
     }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.stereotype.Service;
 import roomescape.controller.dto.RequestReservation;
+import roomescape.dao.ReservationDao;
 import roomescape.domain.Reservation;
 import roomescape.global.exception.NotFoundException;
 
@@ -13,6 +14,11 @@ public class ReservationService {
 
     private final AtomicLong index = new AtomicLong(1);
     private final List<Reservation> reservations = new ArrayList<>();
+    private final ReservationDao reservationDao;
+
+    public ReservationService(final ReservationDao reservationDao) {
+        this.reservationDao = reservationDao;
+    }
 
     public Reservation create(final RequestReservation requestReservation) {
         Long id = index.getAndIncrement();
@@ -24,7 +30,7 @@ public class ReservationService {
     }
 
     public List<Reservation> findAll() {
-        return reservations;
+        return reservationDao.findAllReservation();
     }
 
     public Reservation findById(final Long id) {

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -1,8 +1,6 @@
 package roomescape.service;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 import org.springframework.stereotype.Service;
 import roomescape.controller.dto.RequestReservation;
 import roomescape.dao.ReservationDao;
@@ -12,8 +10,6 @@ import roomescape.global.exception.NotFoundException;
 @Service
 public class ReservationService {
 
-    private final AtomicLong index = new AtomicLong(1);
-    private final List<Reservation> reservations = new ArrayList<>();
     private final ReservationDao reservationDao;
 
     public ReservationService(final ReservationDao reservationDao) {
@@ -21,27 +17,21 @@ public class ReservationService {
     }
 
     public Reservation create(final RequestReservation requestReservation) {
-        Long id = index.getAndIncrement();
         requestReservation.validatePasted();
-        Reservation reservation = Reservation.of(id, requestReservation.name(),
-                requestReservation.parseDate(), requestReservation.parseTime());
-        reservations.add(reservation);
-        return reservation;
+        return reservationDao.save(requestReservation);
     }
 
     public List<Reservation> findAll() {
-        return reservationDao.findAllReservation();
+        return reservationDao.findAll();
     }
 
     public Reservation findById(final Long id) {
-        return reservations.stream()
-                .filter(reservation -> reservation.id().equals(id))
-                .findFirst()
+        return reservationDao.findById(id)
                 .orElseThrow(() -> new NotFoundException("예약 ID가 존재하지 않아요."));
     }
 
     public void delete(final Long id) {
         Reservation reservation = findById(id);
-        reservations.remove(reservation);
+        reservationDao.deleteById(reservation.id());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.datasource.url=jdbc:h2:mem:database

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE reservation
+(
+    id      BIGINT       NOT NULL AUTO_INCREMENT,
+    name    VARCHAR(255) NOT NULL,
+    date    VARCHAR(255) NOT NULL,
+    time    VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -11,6 +11,7 @@ import io.restassured.http.ContentType;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.junit.jupiter.api.DisplayName;
@@ -19,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.domain.Reservation;
 
 @SpringBootTest(webEnvironment = DEFINED_PORT)
 @DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
@@ -65,8 +67,8 @@ public class MissionStepTest {
         RestAssured.given().log().all()
                 .when().get("/reservations")
                 .then().log().all()
-                .statusCode(200)
-                .body("size()", is(1));
+                .statusCode(200).extract()
+                .jsonPath().getList(".", Reservation.class);
     }
 
     @Test
@@ -150,5 +152,24 @@ public class MissionStepTest {
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    @DisplayName("예약 테이블에 예약을 추가한 후 정상적으로 조회가 된다.")
+    void shouldReturnCountRow_whenAddReservation() {
+        String sql = "INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)";
+        jdbcTemplate.update(sql, "브라운", "2023-08-05", "15:40");
+
+        List<Reservation> reservations = RestAssured
+                .given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200).extract()
+                .jsonPath().getList(".", Reservation.class);
+
+        String countSql = "SELECT count(1) from reservation";
+        Integer count = jdbcTemplate.queryForObject(countSql, Integer.class);
+
+        assertThat(reservations.size()).isEqualTo(count);
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -1,5 +1,6 @@
 package roomescape;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
@@ -7,16 +8,24 @@ import static org.springframework.test.annotation.DirtiesContext.ClassMode.BEFOR
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 
 @SpringBootTest(webEnvironment = DEFINED_PORT)
 @DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @Test
     @DisplayName("기본 URI로 요청 시 정상적으로 어드민 페이지가 반환된다.")
@@ -128,5 +137,18 @@ public class MissionStepTest {
                 .then().log().all()
                 .statusCode(400)
                 .body(containsString("예약 ID가 존재하지 않아요."));
+    }
+
+
+    @Test
+    @DisplayName("정상적으로 데이터베이스가 연결되어 예약 테이블이 생성된다.")
+    void shouldCreateReservationTable() {
+        try (Connection connection = Objects.requireNonNull(jdbcTemplate.getDataSource()).getConnection()) {
+            assertThat(connection).isNotNull();
+            assertThat(connection.getCatalog()).isEqualTo("DATABASE");
+            assertThat(connection.getMetaData().getTables(null, null, "RESERVATION", null).next()).isTrue();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,9 +26,6 @@ import roomescape.domain.Reservation;
 @SpringBootTest(webEnvironment = DEFINED_PORT)
 @DirtiesContext(classMode = BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
-
-    @Autowired
-    private JdbcTemplate jdbcTemplate;
 
     @Test
     @DisplayName("기본 URI로 요청 시 정상적으로 어드민 페이지가 반환된다.")
@@ -93,8 +91,7 @@ public class MissionStepTest {
         RestAssured.given().log().all()
                 .when().get("/reservations")
                 .then().log().all()
-                .statusCode(200)
-                .body("size()", is(0));
+                .statusCode(200);
     }
 
     @Test
@@ -141,35 +138,87 @@ public class MissionStepTest {
                 .body(containsString("예약 ID가 존재하지 않아요."));
     }
 
+    @Nested
+    @DisplayName("데이터베이스 테스트")
+    class DatabaseTest {
 
-    @Test
-    @DisplayName("정상적으로 데이터베이스가 연결되어 예약 테이블이 생성된다.")
-    void shouldCreateReservationTable() {
-        try (Connection connection = Objects.requireNonNull(jdbcTemplate.getDataSource()).getConnection()) {
-            assertThat(connection).isNotNull();
-            assertThat(connection.getCatalog()).isEqualTo("DATABASE");
-            assertThat(connection.getMetaData().getTables(null, null, "RESERVATION", null).next()).isTrue();
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
+        @Autowired
+        private JdbcTemplate jdbcTemplate;
+
+        @Test
+        @DisplayName("정상적으로 데이터베이스가 연결되어 예약 테이블이 생성된다.")
+        void shouldCreateReservationTable() {
+            try (Connection connection = Objects.requireNonNull(jdbcTemplate.getDataSource()).getConnection()) {
+                assertThat(connection).isNotNull();
+                assertThat(connection.getCatalog()).isEqualTo("DATABASE");
+                assertThat(connection.getMetaData().getTables(null, null, "RESERVATION", null).next()).isTrue();
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
         }
-    }
 
-    @Test
-    @DisplayName("예약 테이블에 예약을 추가한 후 정상적으로 조회가 된다.")
-    void shouldReturnCountRow_whenAddReservation() {
-        String sql = "INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)";
-        jdbcTemplate.update(sql, "브라운", "2023-08-05", "15:40");
+        @Test
+        @DisplayName("예약 테이블에 예약을 추가한 후 정상적으로 조회가 된다.")
+        void shouldReturnDatabaseCountRow_whenAddReservation() {
+            String sql = "INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)";
+            jdbcTemplate.update(sql, "브라운", "2030-08-05", "15:40");
 
-        List<Reservation> reservations = RestAssured
-                .given().log().all()
-                .when().get("/reservations")
-                .then().log().all()
-                .statusCode(200).extract()
-                .jsonPath().getList(".", Reservation.class);
+            List<Reservation> reservations = RestAssured
+                    .given().log().all()
+                    .when().get("/reservations")
+                    .then().log().all()
+                    .statusCode(200).extract()
+                    .jsonPath().getList(".", Reservation.class);
 
-        String countSql = "SELECT count(1) from reservation";
-        Integer count = jdbcTemplate.queryForObject(countSql, Integer.class);
+            String countSql = "SELECT count(1) from reservation";
+            Integer count = jdbcTemplate.queryForObject(countSql, Integer.class);
 
-        assertThat(reservations.size()).isEqualTo(count);
+            assertThat(reservations.size()).isEqualTo(count);
+        }
+
+        @Test
+        @DisplayName("예약 API를 이용하여 예약을 추가한 후 정상적으로 데이터베이스에서 조회가 된다.")
+        void shouldReservationListInDatabase_whenUsingReservationAPI() {
+            Map<String, String> params = new HashMap<>();
+            params.put("name", "브라운");
+            params.put("date", "2027-08-05");
+            params.put("time", "10:00");
+
+            RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(params)
+                    .when().post("/reservations")
+                    .then().log().all()
+                    .statusCode(201)
+                    .header("Location", "/reservations/1");
+
+            Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+            assertThat(count).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("예약 API를 이용하여 예약을 취소하면 정상적으로 데이터베이스에서 삭제가 된다.")
+        void shouldDeleteReservationInDatabase_whenUsingReservationAPI() {
+            Map<String, String> params = new HashMap<>();
+            params.put("name", "브라운");
+            params.put("date", "2027-08-05");
+            params.put("time", "10:00");
+
+            RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(params)
+                    .when().post("/reservations")
+                    .then().log().all()
+                    .statusCode(201)
+                    .header("Location", "/reservations/1");
+
+            RestAssured.given().log().all()
+                    .when().delete("/reservations/1")
+                    .then().log().all()
+                    .statusCode(204);
+
+            Integer countAfterDelete = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+            assertThat(countAfterDelete).isEqualTo(0);
+        }
     }
 }


### PR DESCRIPTION
안녕하세요 주노 🙌
늦어서 죄송합니다ㅠ

벌써 Spring MVC가 끝나고 데베를 다루게 되었네요. 
잘 부탁드립니다!

---

## 🤔 고민한 부분

### 1. 학습 키워드 SimpleJdbcInsert 도입

처음에는 JdbcTemplate의 update()를 사용해서 insert 쿼리를 직접 작성하려고 했습니다.
```java
String sql = "INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)";
jdbcTemplate.update(sql, name, date, time);
```
하지만 이 방식으로 insert하게 되면 자동 생성되는 id를 KeyHolder로 따로 받아서 처리해야 해서 코드가 복잡해졌습니다.

그래서 SimpleJdbcInsert를 도입해보기로 하였습니다.

```java
SimpleJdbcInsert insert = new SimpleJdbcInsert(dataSource)
    .withTableName("reservation")
    .usingGeneratedKeyColumns("id");

Number id = insert.executeAndReturnKey(parameters);
```

SimpleJdbcInsert는 내부적으로 KeyHolder를 지원하기 때문에 별도로 로직을 구성하지 않아도 되는 편리함이 있었습니다.
또한 쿼리를 직접 작성하지 않아서 간결해졌습니다!

### 2. JdbcTemplate -> NamedParameterJdbcTemplate
기존에는 `?` 기반으로 파라미터를 설정했는데, 파라미터가 여러 개일 경우 순서가 헷갈리거나 실수할 위험이 크다고 느꼈습니다.

```java
String sql = "SELECT * FROM reservation WHERE id = ?";
jdbcTemplate.query(sql, rowMapper, id);
```

그래서 파라미터 이름을 명시할 수 있는 NamedParameterJdbcTemplate으로 전환해봤습니다.
```java
String sql = "SELECT * FROM reservation WHERE id = :id";
Map<String, Object> params = Map.of("id", id);
namedParameterJdbcTemplate.query(sql, params, rowMapper);
```

이와 같이 Map을 기반으로 값을 주입해주기 때문에 실수도 방지하면서 어떤 파라미터가 들어가는지 명확하게 표현할 수 있었습니다!

### 3. 테스트 코드 분리 고민
처음에는 하나의 테스트 class에 JDBCTemplate을 `@Autowired`로 주입해주었습니다.

DB 접근 테스트가 많아지다 보니 조회/저장/삭제 검증과 실제 연결 확인 테스트를 구분해서 `@Nested`로 구조화하고 싶었습니다.
그런데 처음에는 `@Nested` 클래스 내부에서 `@Autowired`가 동작하지 않아 JdbcTemplate이 null이 되는 문제가 발생하더라구요.

그래서 `@Nested` 내부로 옮기니 정상 동작하게 되었습니다!

> 아예 테스트를 분리하는게 나을지 고민 중 입니다 🤔

## 🙋🏻‍♀️ 궁금한 부분
- 실무에서도 SimpleJdbcInsert나 NamedParameterJdbcTemplate을 주로 사용하는지, 아니면 JdbcTemplate으로 충분한 경우가 더 많은지 궁금합니다.

- 테스트 내에서 DB 접근과 단순 로직 테스트를 어떻게 분리하면 좋을지, 더 나은 테스트 구조가 있는지 궁금합니다!
