### PR TITLE
[ Spring JDBC ] 박채연 미션 제출 합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    runtimeOnly 'com.h2database:h2'
 }
 
 test {

--- a/src/main/java/roomescape/repository/JdbcReservationRepository.java
+++ b/src/main/java/roomescape/repository/JdbcReservationRepository.java
@@ -1,0 +1,63 @@
+package roomescape.repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+import org.springframework.stereotype.Repository;
+import roomescape.domain.Reservation;
+import roomescape.dto.ReservationResponse;
+
+@Repository
+public class JdbcReservationRepository implements ReservationRepository {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final SimpleJdbcInsert insert;
+
+    public JdbcReservationRepository(DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+        this.insert = new SimpleJdbcInsert(dataSource)
+                .withTableName("reservation")
+                .usingGeneratedKeyColumns("id");
+    }
+
+    private final RowMapper<Reservation> rowMapper = (rs, rowNum) -> Reservation.of(
+            rs.getLong("id"),
+            rs.getString("name"),
+            rs.getDate("date").toLocalDate(),
+            rs.getTime("time").toLocalTime()
+    );
+
+    @Override
+    public List<ReservationResponse> findAll() {
+        List<Reservation> reservations = jdbcTemplate.query("SELECT * FROM reservation ORDER BY id", rowMapper);
+        return reservations.stream()
+                .map(ReservationResponse::new)
+                .toList();
+    }
+
+    @Override
+    public ReservationResponse save(Reservation reservation) {
+        Number key = insert.executeAndReturnKey(Map.of(
+                "name", reservation.getName(),
+                "date", reservation.getDate(),
+                "time", reservation.getTime()
+        ));
+        Reservation saved = Reservation.of(
+                key.longValue(),
+                reservation.getName(),
+                reservation.getDate(),
+                reservation.getTime()
+        );
+        return new ReservationResponse(saved);
+    }
+
+
+    @Override
+    public int deleteById(Long id) {
+        return jdbcTemplate.update("DELETE FROM reservation WHERE id = ?", id);
+    }
+}

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -1,0 +1,13 @@
+package roomescape.repository;
+
+import java.util.List;
+import roomescape.domain.Reservation;
+import roomescape.dto.ReservationResponse;
+
+public interface ReservationRepository {
+    List<ReservationResponse> findAll();
+
+    ReservationResponse save(Reservation reservation);
+
+    int deleteById(Long id);
+}

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -1,23 +1,27 @@
 package roomescape.service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
-import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Service;
 import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
-import roomescape.exception.status.ReservationNotFoundException;
 
 @Service
 public class ReservationService {
     private final JdbcTemplate jdbcTemplate;
+    private final SimpleJdbcInsert jdbcInsert;
 
     public ReservationService(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
+        this.jdbcInsert = new SimpleJdbcInsert(jdbcTemplate)
+                .withTableName("reservation")
+                .usingGeneratedKeyColumns("id");
     }
 
     public List<ReservationResponse> findAll() {
@@ -37,15 +41,14 @@ public class ReservationService {
     }
 
     public ReservationResponse create(ReservationRequest request) {
-        jdbcTemplate.update(
-                "INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)",
-                request.getName(),
-                request.getDate(),
-                request.getTime()
-        );
+        Map<String, Object> params = new HashMap<>();
+        params.put("name", request.getName());
+        params.put("date", request.getDate());
+        params.put("time", request.getTime());
 
-        Long id = jdbcTemplate.queryForObject("SELECT MAX(id) FROM reservation", Long.class);
-        Reservation saved = Reservation.of(id, request.getName(), request.getDate(), request.getTime());
+        Number generatedId = jdbcInsert.executeAndReturnKey(new MapSqlParameterSource(params));
+        Reservation saved = Reservation.of(generatedId.longValue(), request.getName(), request.getDate(),
+                request.getTime());
 
         return new ReservationResponse(saved);
     }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequest;
@@ -12,22 +14,44 @@ import roomescape.exception.status.ReservationNotFoundException;
 
 @Service
 public class ReservationService {
-    private final List<Reservation> reservations = new ArrayList<>();
-    private final AtomicLong index = new AtomicLong(1);
+    private final JdbcTemplate jdbcTemplate;
 
-    public ReservationResponse create(ReservationRequest request) {
-        Reservation reservation = Reservation.of(index.getAndIncrement(), request.getName(), request.getDate(), request.getTime());
-        reservations.add(reservation);
-        return new ReservationResponse(reservation);
+    public ReservationService(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     public List<ReservationResponse> findAll() {
-        return reservations.stream().map(ReservationResponse::new).toList();
+        List<Reservation> reservations = jdbcTemplate.query(
+                "SELECT * FROM reservation",
+                (rs, rowNum) -> Reservation.of(
+                        rs.getLong("id"),
+                        rs.getString("name"),
+                        rs.getDate("date").toLocalDate(),
+                        rs.getTime("time").toLocalTime()
+                )
+        );
+
+        return reservations.stream()
+                .map(ReservationResponse::new)
+                .toList();
+    }
+
+    public ReservationResponse create(ReservationRequest request) {
+        jdbcTemplate.update(
+                "INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)",
+                request.getName(),
+                request.getDate(),
+                request.getTime()
+        );
+
+        Long id = jdbcTemplate.queryForObject("SELECT MAX(id) FROM reservation", Long.class);
+        Reservation saved = Reservation.of(id, request.getName(), request.getDate(), request.getTime());
+
+        return new ReservationResponse(saved);
     }
 
     public void deleteById(Long id) {
-        boolean removed = reservations.removeIf(r -> r.getId().equals(id));
-        if (!removed) throw new ReservationNotFoundException(id);
+        jdbcTemplate.update("DELETE FROM reservation WHERE id = ?", id);
     }
 }
 

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -12,50 +12,32 @@ import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
 import roomescape.exception.status.ReservationNotFoundException;
+import roomescape.repository.ReservationRepository;
 
 @Service
 public class ReservationService {
-    private final JdbcTemplate jdbcTemplate;
-    private final SimpleJdbcInsert jdbcInsert;
+    private final ReservationRepository reservationRepository;
 
-    public ReservationService(JdbcTemplate jdbcTemplate) {
-        this.jdbcTemplate = jdbcTemplate;
-        this.jdbcInsert = new SimpleJdbcInsert(jdbcTemplate)
-                .withTableName("reservation")
-                .usingGeneratedKeyColumns("id");
+    public ReservationService(ReservationRepository reservationRepository) {
+        this.reservationRepository = reservationRepository;
     }
 
     public List<ReservationResponse> findAll() {
-        List<Reservation> reservations = jdbcTemplate.query(
-                "SELECT * FROM reservation",
-                (rs, rowNum) -> Reservation.of(
-                        rs.getLong("id"),
-                        rs.getString("name"),
-                        rs.getDate("date").toLocalDate(),
-                        rs.getTime("time").toLocalTime()
-                )
-        );
-
-        return reservations.stream()
-                .map(ReservationResponse::new)
-                .toList();
+        return reservationRepository.findAll();
     }
 
     public ReservationResponse create(ReservationRequest request) {
-        Map<String, Object> params = new HashMap<>();
-        params.put("name", request.getName());
-        params.put("date", request.getDate());
-        params.put("time", request.getTime());
-
-        Number generatedId = jdbcInsert.executeAndReturnKey(new MapSqlParameterSource(params));
-        Reservation saved = Reservation.of(generatedId.longValue(), request.getName(), request.getDate(),
-                request.getTime());
-
-        return new ReservationResponse(saved);
+        Reservation reservation = Reservation.of(
+                null,
+                request.getName(),
+                request.getDate(),
+                request.getTime()
+        );
+        return reservationRepository.save(reservation);
     }
 
     public void deleteById(Long id) {
-        int affected = jdbcTemplate.update("DELETE FROM reservation WHERE id = ?", id);
+        int affected = reservationRepository.deleteById(id);
         if (affected == 0) {
             throw new ReservationNotFoundException(id);
         }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
+import roomescape.exception.status.ReservationNotFoundException;
 
 @Service
 public class ReservationService {
@@ -54,7 +55,10 @@ public class ReservationService {
     }
 
     public void deleteById(Long id) {
-        jdbcTemplate.update("DELETE FROM reservation WHERE id = ?", id);
+        int affected = jdbcTemplate.update("DELETE FROM reservation WHERE id = ?", id);
+        if (affected == 0) {
+            throw new ReservationNotFoundException(id);
+        }
     }
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+# h2-console ??? ??
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+# db url
+spring.datasource.url=jdbc:h2:mem:DATABASE

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE reservation
+(
+    id      BIGINT       NOT NULL AUTO_INCREMENT,
+    name    VARCHAR(255) NOT NULL,
+    date    VARCHAR(255) NOT NULL,
+    time    VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -20,6 +20,8 @@ import static org.hamcrest.Matchers.is;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @Test
     void 일단계() {
@@ -99,9 +101,6 @@ public class MissionStepTest {
                 .statusCode(404);
     }
 
-    @Autowired
-    private JdbcTemplate jdbcTemplate;
-
     @Test
     void 오단계() {
         try (Connection connection = jdbcTemplate.getDataSource().getConnection()) {
@@ -115,7 +114,8 @@ public class MissionStepTest {
 
     @Test
     void 육단계() {
-        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "브라운", "2023-08-05", "15:40");
+        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "브라운", "2023-08-05",
+                "15:40");
 
         List<Reservation> reservations = RestAssured.given().log().all()
                 .when().get("/reservations")
@@ -154,7 +154,6 @@ public class MissionStepTest {
         Integer countAfterDelete = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
         assertThat(countAfterDelete).isEqualTo(0);
     }
-
 
 
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -5,12 +5,14 @@ import io.restassured.http.ContentType;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.domain.Reservation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -110,5 +112,21 @@ public class MissionStepTest {
             throw new RuntimeException(e);
         }
     }
+
+    @Test
+    void 육단계() {
+        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "브라운", "2023-08-05", "15:40");
+
+        List<Reservation> reservations = RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200).extract()
+                .jsonPath().getList(".", Reservation.class);
+
+        Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+
+        assertThat(reservations.size()).isEqualTo(count);
+    }
+
 
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -2,12 +2,17 @@ package roomescape;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -92,5 +97,18 @@ public class MissionStepTest {
                 .statusCode(404);
     }
 
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void 오단계() {
+        try (Connection connection = jdbcTemplate.getDataSource().getConnection()) {
+            assertThat(connection).isNotNull();
+            assertThat(connection.getCatalog()).isEqualTo("DATABASE");
+            assertThat(connection.getMetaData().getTables(null, null, "RESERVATION", null).next()).isTrue();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -128,5 +128,33 @@ public class MissionStepTest {
         assertThat(reservations.size()).isEqualTo(count);
     }
 
+    @Test
+    void 칠단계() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "2023-08-05");
+        params.put("time", "10:00");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(201)
+                .header("Location", "/reservations/1");
+
+        Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        assertThat(count).isEqualTo(1);
+
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(204);
+
+        Integer countAfterDelete = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        assertThat(countAfterDelete).isEqualTo(0);
+    }
+
+
 
 }


### PR DESCRIPTION
### 코드리뷰 후 회고
- Service가 DB 접근 책임을 갖는 것은 결합도를 높이므로, 해당 책임을 Repository 계층으로 위임했습니다.
이 과정에서 interface ReservationRepository 를 두어 jdbc 가 아닌 jpa 를 사용하게 될때 구현체를 갈아끼울 수 있도록 했습니다.

- 응답 형식을 유연하게 다루기 위해 dto 를 사용했습니다. Repository를 두게 되니, Service 계층에선 requestDTO를 도메인 객체로 변환하는 로직과 예외 처리 로직을, Repository 계층에선 DB와의 crud 와 도메인 객체를 ResponseDTO로 변환해 전달하고 있습니다.

- 사용자 요청 검증에 대한 부분을 dto에 따로 추가해야할지 궁금합니다! 
---
안녕하세요!  
MVC 미션에 이어 JDBC 미션도 리뷰 요청드립니다 🙇‍♀️

### MVC 커밋 제거해뒀습니다!
- JDBC로 구현해둔 코드를 로컬 backup 브랜치에 백업한 후,  
   브랜치를 upstream 기준으로 싱크했습니다.
- 그 후 cherry-pick으로 필요한 커밋만 새로운 브랜치에 적용하여 PR을 만들었습니다.

### 배운 점
- JDBC Template을 통해 SQL 결과를 Java 객체로 수동 변환하는 과정을 직접 해보며  
  ORM이 내부적으로 수행하는 일을 더 잘 이해하게 되었습니다.
- 또한, 지난 리뷰에서 받은 피드백을 반영하여 Controller에 있던 비즈니스 로직을 Service 계층으로 분리하였습니다.  
  그 결과, 이번 미션에 Service 로직만 수정하면 되어 편했습니다.
