### PR TITLE
[Spring JDBC] 하수한 5, 6, 7단계 미션 제출합니다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
+    runtimeOnly 'com.h2database:h2'
 }
 
 test {

--- a/src/main/java/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/GlobalExceptionHandler.java
@@ -1,9 +1,7 @@
 package roomescape.exception;
 
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,11 +11,6 @@ import roomescape.dto.ErrorResponse;
 public class GlobalExceptionHandler {
     @ExceptionHandler(ReservationNotFoundException.class)
     public ResponseEntity<ErrorResponse> handleReservationNotFoundException(ReservationNotFoundException e) {
-        return new ResponseEntity<>(new ErrorResponse(e.getMessage()), HttpStatus.BAD_REQUEST);
-    }
-
-    @ExceptionHandler(ReservationValidationException.class)
-    public ResponseEntity<ErrorResponse> handleReservationValidationException(ReservationValidationException e) {
         return new ResponseEntity<>(new ErrorResponse(e.getMessage()), HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/roomescape/exception/ReservationValidationException.java
+++ b/src/main/java/roomescape/exception/ReservationValidationException.java
@@ -1,7 +1,0 @@
-package roomescape.exception;
-
-public class ReservationValidationException extends RuntimeException {
-    public ReservationValidationException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/roomescape/model/Reservation.java
+++ b/src/main/java/roomescape/model/Reservation.java
@@ -3,4 +3,12 @@ package roomescape.model;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-public record Reservation(Integer id, String name, LocalDate date, LocalTime time) { }
+public record Reservation(Integer id, String name, LocalDate date, LocalTime time) {
+    public static Reservation of(Integer id, String name, LocalDate date, LocalTime time) {
+        return new Reservation(id, name, date, time);
+    }
+
+    public static Reservation create(String name, LocalDate date, LocalTime time) {
+        return new Reservation(null, name, date, time);
+    }
+}

--- a/src/main/java/roomescape/model/Reservation.java
+++ b/src/main/java/roomescape/model/Reservation.java
@@ -3,4 +3,4 @@ package roomescape.model;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-public record Reservation(int id, String name, LocalDate date, LocalTime time) { }
+public record Reservation(Integer id, String name, LocalDate date, LocalTime time) { }

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -1,7 +1,5 @@
 package roomescape.repository;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.List;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -28,5 +26,22 @@ public class ReservationRepository {
         String query = "SELECT id, name, date, time FROM reservation";
 
         return jdbcTemplate.query(query, reservationMapper);
+    }
+
+    public Reservation save(Reservation reservation) {
+        String query = "INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)";
+
+        jdbcTemplate.update(query, reservation.name(), reservation.date(), reservation.time());
+
+        // get inserted row id
+        int id = jdbcTemplate.queryForObject("SELECT MAX(id) FROM reservation", Integer.class);
+
+        return new Reservation(id, reservation.name(), reservation.date(), reservation.time());
+    }
+
+    public void deleteById(int id) {
+        String query = "DELETE FROM reservation WHERE id = ?";
+
+        jdbcTemplate.update(query, id);
     }
 }

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -15,7 +15,7 @@ public class ReservationRepository {
     private final JdbcTemplate jdbcTemplate;
     private final SimpleJdbcInsert simpleJdbcInsert;
     private final RowMapper<Reservation> reservationMapper = (rs, rowNum) -> {
-        return new Reservation(
+        return Reservation.of(
                 rs.getInt("id"),
                 rs.getString("name"),
                 rs.getDate("date").toLocalDate(),
@@ -45,7 +45,7 @@ public class ReservationRepository {
 
         Number id = simpleJdbcInsert.executeAndReturnKey(params);
 
-        return new Reservation(id.intValue(), reservation.name(), reservation.date(), reservation.time());
+        return Reservation.of(id.intValue(), reservation.name(), reservation.date(), reservation.time());
     }
 
     public void deleteById(int id) {

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -1,0 +1,32 @@
+package roomescape.repository;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+import roomescape.model.Reservation;
+
+@Repository
+public class ReservationRepository {
+    private final JdbcTemplate jdbcTemplate;
+    private final RowMapper<Reservation> reservationMapper = (rs, rowNum) -> {
+        return new Reservation(
+                rs.getInt("id"),
+                rs.getString("name"),
+                rs.getDate("date").toLocalDate(),
+                rs.getTime("time").toLocalTime()
+        );
+    };
+
+    public ReservationRepository(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public List<Reservation> findAll() {
+        String query = "SELECT id, name, date, time FROM reservation";
+
+        return jdbcTemplate.query(query, reservationMapper);
+    }
+}

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -1,14 +1,19 @@
 package roomescape.repository;
 
 import java.util.List;
+import java.util.Map;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 import roomescape.model.Reservation;
 
 @Repository
 public class ReservationRepository {
+    private static final String TABLE_NAME = "reservation";
+
     private final JdbcTemplate jdbcTemplate;
+    private final SimpleJdbcInsert simpleJdbcInsert;
     private final RowMapper<Reservation> reservationMapper = (rs, rowNum) -> {
         return new Reservation(
                 rs.getInt("id"),
@@ -20,27 +25,31 @@ public class ReservationRepository {
 
     public ReservationRepository(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
+        this.simpleJdbcInsert = new SimpleJdbcInsert(jdbcTemplate)
+                .withTableName(TABLE_NAME)
+                .usingGeneratedKeyColumns("id");
     }
 
     public List<Reservation> findAll() {
-        String query = "SELECT id, name, date, time FROM reservation";
+        String query = "SELECT id, name, date, time FROM " + TABLE_NAME;
 
         return jdbcTemplate.query(query, reservationMapper);
     }
 
     public Reservation save(Reservation reservation) {
-        String query = "INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)";
+        Map<String, Object> params = Map.of(
+                "name", reservation.name(),
+                "date", reservation.date(),
+                "time", reservation.time()
+        );
 
-        jdbcTemplate.update(query, reservation.name(), reservation.date(), reservation.time());
+        Number id = simpleJdbcInsert.executeAndReturnKey(params);
 
-        // get inserted row id
-        int id = jdbcTemplate.queryForObject("SELECT MAX(id) FROM reservation", Integer.class);
-
-        return new Reservation(id, reservation.name(), reservation.date(), reservation.time());
+        return new Reservation(id.intValue(), reservation.name(), reservation.date(), reservation.time());
     }
 
     public void deleteById(int id) {
-        String query = "DELETE FROM reservation WHERE id = ?";
+        String query = "DELETE FROM " + TABLE_NAME + " WHERE id = ?";
 
         jdbcTemplate.update(query, id);
     }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -24,7 +24,7 @@ public class ReservationService {
         LocalDate date = LocalDate.parse(request.date());
         LocalTime time = LocalTime.parse(request.time());
 
-        Reservation reservation = new Reservation(null, request.name(), date, time);
+        Reservation reservation = Reservation.create(request.name(), date, time);
 
         return reservationRepository.save(reservation);
     }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -2,10 +2,7 @@ package roomescape.service;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.springframework.stereotype.Service;
 import roomescape.dto.ReservationCreateRequest;
 import roomescape.model.Reservation;
@@ -27,13 +24,12 @@ public class ReservationService {
         LocalDate date = LocalDate.parse(request.date());
         LocalTime time = LocalTime.parse(request.time());
 
-        Reservation reservation = new Reservation(id.incrementAndGet(), request.name(), date, time);
-        reservations.add(reservation);
+        Reservation reservation = new Reservation(null, request.name(), date, time);
 
-        return reservation;
+        return reservationRepository.save(reservation);
     }
 
     public void deleteReservation(int id) {
-       reservations.removeIf((reservation -> reservation.id() == id));
+        reservationRepository.deleteById(id);
     }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -7,10 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
 import roomescape.dto.ReservationCreateRequest;
-import roomescape.exception.ReservationNotFoundException;
-import roomescape.exception.ReservationValidationException;
 import roomescape.model.Reservation;
 
 @Service

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -9,21 +9,18 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.springframework.stereotype.Service;
 import roomescape.dto.ReservationCreateRequest;
 import roomescape.model.Reservation;
+import roomescape.repository.ReservationRepository;
 
 @Service
 public class ReservationService {
-    private final AtomicInteger id;
-    private final List<Reservation> reservations;
+    private final ReservationRepository reservationRepository;
 
-    public ReservationService() {
-        this.id = new AtomicInteger(0);
-        this.reservations = Collections.synchronizedList(new ArrayList<>());
-
-//        populateDefaults();
+    public ReservationService(ReservationRepository reservationRepository) {
+        this.reservationRepository = reservationRepository;
     }
 
     public List<Reservation> getReservations() {
-        return reservations;
+        return reservationRepository.findAll();
     }
 
     public Reservation createReservation(ReservationCreateRequest request) {
@@ -38,15 +35,5 @@ public class ReservationService {
 
     public void deleteReservation(int id) {
        reservations.removeIf((reservation -> reservation.id() == id));
-    }
-
-    private void populateDefaults() {
-        reservations.addAll(
-                List.of(
-                        new Reservation(id.incrementAndGet(), "브라운", LocalDate.parse("2025-01-01"), LocalTime.parse("10:00")),
-                        new Reservation(id.incrementAndGet(), "브라운", LocalDate.parse("2025-01-02"), LocalTime.parse("11:00")),
-                        new Reservation(id.incrementAndGet(), "브라운", LocalDate.parse("2025-01-03"), LocalTime.parse("12:00"))
-                )
-        );
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+spring.h2.console.enabled=true
+spring.datasource.url=jdbc:h2:mem:database

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE reservation
 (
     id      BIGINT       NOT NULL AUTO_INCREMENT,
     name    VARCHAR(255) NOT NULL,
-    date    VARCHAR(255) NOT NULL,
-    time    VARCHAR(255) NOT NULL,
+    date    DATE         NOT NULL,
+    time    TIME         NOT NULL,
     PRIMARY KEY (id)
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE reservation
+(
+    id      BIGINT       NOT NULL AUTO_INCREMENT,
+    name    VARCHAR(255) NOT NULL,
+    date    VARCHAR(255) NOT NULL,
+    time    VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -127,4 +127,31 @@ public class MissionStepTest {
 
         assertThat(reservations.size()).isEqualTo(count);
     }
+
+    @Test
+    void 칠단계() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "2023-08-05");
+        params.put("time", "10:00");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(201)
+                .header("Location", "/reservations/1");
+
+        Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        assertThat(count).isEqualTo(1);
+
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(204);
+
+        Integer countAfterDelete = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+        assertThat(countAfterDelete).isEqualTo(0);
+    }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -112,4 +112,19 @@ public class MissionStepTest {
             throw new RuntimeException(e);
         }
     }
+
+    @Test
+    void 육단계() {
+        jdbcTemplate.update("INSERT INTO reservation (name, date, time) VALUES (?, ?, ?)", "브라운", "2023-08-05", "15:40");
+
+        List<Reservation> reservations = RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200).extract()
+                .jsonPath().getList(".", Reservation.class);
+
+        Integer count = jdbcTemplate.queryForObject("SELECT count(1) from reservation", Integer.class);
+
+        assertThat(reservations.size()).isEqualTo(count);
+    }
 }

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -1,19 +1,28 @@
 package roomescape;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.model.Reservation;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SuppressWarnings("NonAsciiCharacters")
 public class MissionStepTest {
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @Test
     void 일단계() {
@@ -90,6 +99,17 @@ public class MissionStepTest {
         RestAssured.given().log().all()
                 .when().delete("/reservations/1")
                 .then().log().all()
-                .statusCode(400);
+                .statusCode(204);
+    }
+
+    @Test
+    void 오단계() {
+        try (Connection connection = jdbcTemplate.getDataSource().getConnection()) {
+            assertThat(connection).isNotNull();
+            assertThat(connection.getCatalog()).isEqualTo("DATABASE");
+            assertThat(connection.getMetaData().getTables(null, null, "RESERVATION", null).next()).isTrue();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
다빈님 안녕하세요! 지난 로또 미션 이후로 오랜만에 뵙는 것 같습니다! 이번 미션도 잘 부탁드립니다!!
이번 미션에서는 기존 `ArrayList`기반 CRUD 로직을 `h2` 기반으로 마이그레이션을 진행했습니다.

다음은 현재 프로젝트 구조입니다.
```
controller/
- HomeController.java : 메인 화면 관련 endpoint를 처리하는 컨트롤러
- ReservationController.java : 예약 관련 endpoint를 처리하는 컨트롤러
dto/
- ErrorResponse.java : 오류 응답 정보를 담을 객체
- ReservationCreateRequest.java : 예약 생성 요청 Payload를 담을 객체
- ReservationCreateResponse.java : 예약 생성 요청 응답 정보를 담을 객체
exception/
- GlobalExceptionHandler.java : 공통 예외 핸들러
- ReservationNotFoundException.java : 예약을 찾을 수 없을 때 발생하는 Custom Exception
model/
- Reservation.java : 예약 데이터의 구조를 정의한 Record
repository/
- ReservationRepository.java : DB에서 데이터를 읽고 쓰는 기능을 캡슐화한 객체
service/
- ReservationService.java : 예약 관련 비즈니스 로직을 담은 객체
validation/
- DateVaildator.java : ValidDate 어노테이션의 검증 로직
- TimeValidator.java: ValidTime 어노테이션의 검증 로직
- ValidDate.java : 날짜를 검증하기 위한 Custom bean validator
- ValidTime.java : 시간을 검증하기 위한 Custom bean validator
RoomescapeApplication.java : Main entrypoint
```

다음은 구현 과정에서 발생한 질문 사항입니다.

1. DB 마이그레이션을 진행하면서 더 이상 id와 CRUD 연산에 대해 동시성 문제를 고려하는 코드(`AtomicInt`, `Collections.synchronizedList()`)가 필요 없어졌는데, 이 경우 DB 내부적으로 이러한 동시성 문제를 알아서 고려하여 처리해주는 것일까요?

2. 예약 생성 로직에서 repository로 정보를 넘겨주는 과정에서 `Reservation` 객체를 생성하여 넘겨주는데, 해당 시점에서는 id값이 존재하지 않아 명시적으로 null로 지정하여 넘겨주고 있습니다. 물론 이후 Repository에서 DB insert 이후 나온 id값으로 다시 객체를 생성하여 돌려주긴 하지만, 이러한 방식이 적절한 것인지 궁금합니다!

3. `ReservationRepository::save()` 로직에서 insert 연산 이후 삽입된 row의 id값을 `MAX(id)`를 통해 가져오고 있는데(삽입 시 id값이 중가, 삽입 후 id의 max 값은 바로 직전에 삽입한 row의 id 값일 거라 예상), 이 로직에서 동시성 문제가 발생할 가능성이 있는지, 만약 그렇다면 삽입된 row의 id값을 가져올 수 있는 더 좋은 방법이 있는지 궁금합니다!

긴 글 읽어주셔서 감사드리며, 항상 감사드립니다!! 🙂