### PR TITLE
[RIPL] 정종진 스프링 MVC 3,4단계 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 - 사용자는 어드민 메인 페이지에 접속할 수 있다.
 - 사용자는 예약 관리 페이지에서 전체 예약 목록을 조회할 수 있다.
+- 사용자는 예약 관리 페이지에서 예약을 추가할 수 있다.
+- 사용자는 예약 관리 페이지에서 예약을 취소할 수 있다.
 
 ## System Requirement
 
@@ -13,3 +15,11 @@
 - [x] `GET /reservation` 요청 시 예약 관리 페이지(`reservation.html`)를 응답한다.
 - [x] `GET /reservations` 요청 시 전체 예약 목록을 JSON으로 응답한다.
   - [x] 각 예약은 `id`, `name`, `date`, `time` 필드를 가진다.
+- [x] `POST /reservations` 요청 시 예약을 추가한다.
+  - [x] 요청의 `name`, `date`, `time`으로 예약을 생성하고, 식별자(`id`)는 서버에서 발급한다.
+  - [x] 응답은 `201 Created`이며, `Location: /reservations/{id}` 헤더와 생성된 예약을 바디에 포함한다.
+- [x] `DELETE /reservations/{id}` 요청 시 해당 예약을 취소한다.
+  - [x] 응답은 `204 No Content`이며 본문이 없다.
+- [x] 잘못된 요청은 적절한 Status Code로 응답한다.
+  - [x] 예약 추가 시 `name`, `date`, `time` 중 비어 있는 값이 있으면 `400 Bad Request`로 응답한다.
+  - [x] 삭제할 예약을 식별자로 찾을 수 없으면 `404 Not Found`로 응답한다.

--- a/src/main/java/roomescape/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package roomescape;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import roomescape.exception.InvalidReservationException;
+import roomescape.exception.NotFoundReservationException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(InvalidReservationException.class)
+    public ResponseEntity<String> handleInvalidReservationException(InvalidReservationException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+
+    @ExceptionHandler(NotFoundReservationException.class)
+    public ResponseEntity<String> handleNotFoundReservationException(NotFoundReservationException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
+    }
+}

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
+import roomescape.exception.NotFoundReservationException;
 import roomescape.repository.ReservationRepository;
 
 import java.net.URI;
@@ -48,7 +49,10 @@ public class ReservationController {
     public ResponseEntity<Void> deleteReservation(
             @PathVariable Long id
     ) {
-        reservationRepository.deleteById(id);
+        boolean deleted = reservationRepository.deleteById(id);
+        if (!deleted) {
+            throw new NotFoundReservationException("예약을 찾을 수 없습니다. id=" + id);
+        }
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -2,7 +2,9 @@ package roomescape.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -40,5 +42,14 @@ public class ReservationController {
         return ResponseEntity
                 .created(URI.create("/reservations/" + saved.getId()))
                 .body(ReservationResponse.from(saved));
+    }
+
+    @DeleteMapping("/reservations/{id}")
+    public ResponseEntity<Void> deleteReservation(
+            @PathVariable Long id
+    ) {
+        reservationRepository.deleteById(id);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -1,29 +1,44 @@
 package roomescape.controller;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 import roomescape.domain.Reservation;
+import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
+import roomescape.repository.ReservationRepository;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.ArrayList;
+import java.net.URI;
 import java.util.List;
 
 @Controller
 @ResponseBody // @Controller + @ResponseBody = @RestController
 public class ReservationController {
 
-    private final List<Reservation> reservations = new ArrayList<>(List.of(
-            new Reservation(1L, "브라운", LocalDate.parse("2023-01-01"), LocalTime.parse("10:00")),
-            new Reservation(2L, "브라운", LocalDate.parse("2023-01-02"), LocalTime.parse("11:00"))
-    ));
+    private final ReservationRepository reservationRepository;
+
+    public ReservationController(ReservationRepository reservationRepository) {
+        this.reservationRepository = reservationRepository;
+    }
 
     @GetMapping("/reservations")
     public List<ReservationResponse> getReservations() {
-        return reservations.stream()
+        return reservationRepository.findAll().stream()
                 .map(ReservationResponse::from)
                 .toList();
+    }
+
+    @PostMapping("/reservations")
+    public ResponseEntity<ReservationResponse> createReservation(
+            @RequestBody ReservationRequest request
+    ) {
+        Reservation saved = reservationRepository.save(request.toReservation());
+
+        return ResponseEntity
+                .created(URI.create("/reservations/" + saved.getId()))
+                .body(ReservationResponse.from(saved));
     }
 }

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -17,6 +17,10 @@ public class Reservation {
         this.time = time;
     }
 
+    public Reservation(String name, LocalDate date, LocalTime time) {
+        this(null, name, date, time);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/roomescape/dto/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/ReservationRequest.java
@@ -1,6 +1,7 @@
 package roomescape.dto;
 
 import roomescape.domain.Reservation;
+import roomescape.exception.InvalidReservationException;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -11,10 +12,21 @@ public record ReservationRequest(
         String time
 ) {
     public Reservation toReservation() {
+        validate();
         return new Reservation(
                 name,
                 LocalDate.parse(date),
                 LocalTime.parse(time)
         );
+    }
+
+    private void validate() {
+        if (isBlank(name) || isBlank(date) || isBlank(time)) {
+            throw new InvalidReservationException("예약에 필요한 인자가 없습니다.");
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/src/main/java/roomescape/dto/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/ReservationRequest.java
@@ -1,0 +1,20 @@
+package roomescape.dto;
+
+import roomescape.domain.Reservation;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record ReservationRequest(
+        String name,
+        String date,
+        String time
+) {
+    public Reservation toReservation() {
+        return new Reservation(
+                name,
+                LocalDate.parse(date),
+                LocalTime.parse(time)
+        );
+    }
+}

--- a/src/main/java/roomescape/exception/InvalidReservationException.java
+++ b/src/main/java/roomescape/exception/InvalidReservationException.java
@@ -1,0 +1,8 @@
+package roomescape.exception;
+
+public class InvalidReservationException extends RuntimeException {
+
+    public InvalidReservationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/exception/NotFoundReservationException.java
+++ b/src/main/java/roomescape/exception/NotFoundReservationException.java
@@ -1,0 +1,8 @@
+package roomescape.exception;
+
+public class NotFoundReservationException extends RuntimeException {
+
+    public NotFoundReservationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -1,0 +1,30 @@
+package roomescape.repository;
+
+import org.springframework.stereotype.Repository;
+import roomescape.domain.Reservation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class ReservationRepository {
+
+    private final List<Reservation> reservations = new ArrayList<>();
+    private final AtomicLong index = new AtomicLong(0);
+
+    public List<Reservation> findAll() {
+        return List.copyOf(reservations);
+    }
+
+    public Reservation save(Reservation reservation) {
+        Reservation saved = new Reservation(
+                index.incrementAndGet(),
+                reservation.getName(),
+                reservation.getDate(),
+                reservation.getTime()
+        );
+        reservations.add(saved);
+        return saved;
+    }
+}

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -27,4 +27,8 @@ public class ReservationRepository {
         reservations.add(saved);
         return saved;
     }
+
+    public void deleteById(Long id) {
+        reservations.removeIf(reservation -> reservation.getId().equals(id));
+    }
 }

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -28,7 +28,7 @@ public class ReservationRepository {
         return saved;
     }
 
-    public void deleteById(Long id) {
-        reservations.removeIf(reservation -> reservation.getId().equals(id));
+    public boolean deleteById(Long id) {
+        return reservations.removeIf(reservation -> reservation.getId().equals(id));
     }
 }

--- a/src/test/java/roomescape/HomeControllerTest.java
+++ b/src/test/java/roomescape/HomeControllerTest.java
@@ -1,13 +1,21 @@
 package roomescape;
 
 import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.boot.test.web.server.LocalServerPort;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class HomeControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
 
     @Test
     void 관리자_페이지_반환() {

--- a/src/test/java/roomescape/ReservationControllerTest.java
+++ b/src/test/java/roomescape/ReservationControllerTest.java
@@ -3,6 +3,9 @@ package roomescape;
 import static org.hamcrest.Matchers.is;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -17,6 +20,29 @@ class ReservationControllerTest {
                 .when().get("/reservations")
                 .then().log().all()
                 .statusCode(200)
-                .body("size()", is(2));
+                .body("size()", is(0));
+    }
+
+    @Test
+    void 예약_추가_json_반환() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "2023-08-05");
+        params.put("time", "15:40");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(201)
+                .header("Location", "/reservations/1")
+                .body("id", is(1));
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(1));
     }
 }

--- a/src/test/java/roomescape/ReservationControllerTest.java
+++ b/src/test/java/roomescape/ReservationControllerTest.java
@@ -56,4 +56,24 @@ class ReservationControllerTest {
                 .statusCode(200)
                 .body("size()", is(0));
     }
+
+    @Test
+    void 예외_처리() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "");
+        params.put("time", "");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(400);
+
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(404);
+    }
 }

--- a/src/test/java/roomescape/ReservationControllerTest.java
+++ b/src/test/java/roomescape/ReservationControllerTest.java
@@ -24,7 +24,7 @@ class ReservationControllerTest {
     }
 
     @Test
-    void 예약_추가_json_반환() {
+    void 예약_추가_취소() {
         Map<String, String> params = new HashMap<>();
         params.put("name", "브라운");
         params.put("date", "2023-08-05");
@@ -44,5 +44,16 @@ class ReservationControllerTest {
                 .then().log().all()
                 .statusCode(200)
                 .body("size()", is(1));
+
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(204);
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(0));
     }
 }

--- a/src/test/java/roomescape/ReservationControllerTest.java
+++ b/src/test/java/roomescape/ReservationControllerTest.java
@@ -34,7 +34,7 @@ class ReservationControllerTest {
     }
 
     @Test
-    void 예약_추가_취소() {
+    void 예약_추가() {
         Map<String, String> params = new HashMap<>();
         params.put("name", "브라운");
         params.put("date", "2023-08-05");
@@ -48,23 +48,16 @@ class ReservationControllerTest {
                 .statusCode(201)
                 .header("Location", "/reservations/1")
                 .body("id", is(1));
+    }
 
-        RestAssured.given().log().all()
-                .when().get("/reservations")
-                .then().log().all()
-                .statusCode(200)
-                .body("size()", is(1));
+    @Test
+    void 예약_취소() {
+        예약을_추가한다();
 
         RestAssured.given().log().all()
                 .when().delete("/reservations/1")
                 .then().log().all()
                 .statusCode(204);
-
-        RestAssured.given().log().all()
-                .when().get("/reservations")
-                .then().log().all()
-                .statusCode(200)
-                .body("size()", is(0));
     }
 
     @Test
@@ -85,5 +78,18 @@ class ReservationControllerTest {
                 .when().delete("/reservations/1")
                 .then().log().all()
                 .statusCode(404);
+    }
+
+    private void 예약을_추가한다() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "2023-08-05");
+        params.put("time", "15:40");
+
+        RestAssured.given()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().statusCode(201);
     }
 }

--- a/src/test/java/roomescape/ReservationControllerTest.java
+++ b/src/test/java/roomescape/ReservationControllerTest.java
@@ -6,13 +6,23 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 class ReservationControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
 
     @Test
     void 예약_목록_json_반환() {

--- a/src/test/java/roomescape/ReservationPageControllerTest.java
+++ b/src/test/java/roomescape/ReservationPageControllerTest.java
@@ -1,13 +1,21 @@
 package roomescape;
 
 import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.boot.test.web.server.LocalServerPort;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class ReservationPageControllerTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
 
     @Test
     void 예약_페이지_반환() {


### PR DESCRIPTION
안녕하세요 동건님!
지난주에 이어 Spring MVC 3~4단계 미션으로 인사드리는 정종진입니다.

이번 미션은 예약 추가/취소 API와 예외 처리를 구현했습니다.
이번에도 구현하면서 고민했던 점들을 아래에 정리했습니다.

이번 주도 잘 부탁드립니다!

---

## 어려웠던 점

구현 자체는 지난 미션과 크게 다르지 않아서 기능을 만드는 데 어려움은 없었습니다.


## 중점적으로 봐주었으면 하는 부분

### 컨트롤러의 `List`를 `Repository`로 분리

> 단순하더라도 데이터 접근 책임은 미리 분리해두는 편이 좋을까요?

지난 PR에서 위와 같이 질문드렸었는데,
이번에 예약 추가/취소 기능이 들어오면서 컨트롤러가 HTTP 요청 처리에 더해 저장, 삭제까지
책임을 가지게 되어 `ReservationRepository`로 분리했습니다.

분리하면서 `id` 발급 책임도 함께 옮겼습니다. 
미션 힌트에서는 아래처럼 컨트롤러에서 `AtomicLong`으로 `id`를 발급하는 예시를 주었지만, 
`id` 발급은 "새 예약을 저장한다"는 책임의 일부라고 판단해서 
`Repository`가 저장 시점에 `id`를 발급해 새 `Reservation`을 만들어 반환하도록 했습니다.

<details>
<summary>식별자 처리</summary>
<img width="719" height="334" alt="image" src="https://github.com/user-attachments/assets/a9356631-a5e5-4203-b267-6181a0db26d1" />
</details>

이를 위해 도메인에는 `id` 없는 생성자를 추가했습니다.

요청을 `DTO`인 채로 안쪽까지 넘기지 않고 컨트롤러에서 바로 도메인으로 변환한 이유는,
`DTO`가 안쪽 계층까지 흘러 들어가면 그 계층들이 `DTO`의 구조까지 알아야 하기 때문입니다.
`DTO`는 웹에서 온 요청을 직렬화/역직렬화하기 위한 웹 계층의 사정일 뿐이고,
안쪽 계층은 `Reservation`이라는 도메인만 알면 된다고 생각했습니다.
지금은 `Service` 계층이 없어서 이 원칙이 적용되는 안쪽 계층이 `Repository`뿐이지만,
나중에 `Service`가 생기더라도 변환은 컨트롤러에서 끝내고 안쪽으로는 도메인만 넘기는 구조를 유지하고 싶었습니다.

### 검증 로직의 위치와 범위

필수 값 검증을 `ReservationRequest.validate()`로 요청 `DTO` 안에 두고, 
`toReservation()`에서 검증을 거친 뒤 도메인으로 변환하도록 했습니다. 
컨트롤러에 두면 HTTP 요청/응답 처리 외의 책임까지 떠안게 된다고 느꼈고,
요청 값의 유효성은 그 값을 직접 들고 있는 요청 `DTO`가 판단하는 것이 자연스럽다고 생각했습니다.

다만 테스트하면서 검증이 놓치는 지점을 발견했습니다.
빈 값은 `validate()`에서 걸러져 400으로 처리되지만,
아래처럼 날짜/시간 형식이 잘못된 요청은 검증을 통과한 뒤 `LocalDate.parse()` / `LocalTime.parse()`에서
`DateTimeParseException`이 발생해 500으로 떨어집니다.

<details>
<summary>응답 사진</summary>
<img width="420" height="292" alt="image" src="https://github.com/user-attachments/assets/23a6401e-a659-457e-b27a-c6ebf039c2a5" />
</details>

클라이언트가 잘못된 값을 보낸 것이니 400으로 응답해야 한다고 생각하는데, 방법이 두 가지로 나뉘는 것 같습니다.

1. 예외 핸들러에 `DateTimeParseException` 처리를 추가해서 400으로 응답한다.
2. `validate()`에서 파싱까지 시도해보고, 실패하면 빈 값과 동일하게 `InvalidReservationException`을 던진다.

1번은 파싱 실패를 예외 핸들러가 뒤에서 수습하는 방식이고,
2번은 형식이 올바른가까지 검증 책임으로 보고 `DTO`가 처음부터 걸러내는 방식입니다.

지금도 문자열을 도메인 타입으로 바꾸는 파싱 자체는 `DTO`가 맡고 있고,
스프링 프로젝트에서 Bean Validation을 쓸 때도 `@Email`, `@Pattern`처럼 형식을 검증하는
어노테이션을 사용했던 걸 떠올려보면, 형식 검증도 검증의 범주에 들어간다고 느꼈습니다.
그래서 저는 2번이 맞다고 생각하는데, 이 판단이 적절한지 궁금합니다.

### `Service` 계층 없이 `Controller` → `Repository` 직접 호출

지금은 비즈니스 로직이 거의 없어서 `Service` 계층 없이 컨트롤러가 `Repository`를 직접 호출합니다.
나중에 로직이 생기면 그때 `Service`를 추가할 생각인데, 계층을 미리 갖춰두는 것과
필요해질 때 추가하는 것 중 어느 쪽이 나을지 의견이 궁금합니다.