### PR TITLE
[완두콩] 조하은 Spring MVC 3, 4단계 미션 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# 방 탈출 예약 관리 - Spring MVC (1~2단계)
+# 방 탈출 예약 관리 - Spring MVC (1~4단계)
 
 ## 미션 소개
 
 Spring MVC를 활용하여 방탈출 어드민 페이지를 구성하고,
-예약 관리 페이지와 예약 목록 조회 API를 구현하는 프로젝트
+예약 조회, 생성, 삭제 기능을 제공하는 예약 관리 API를 구현하는 프로젝트
 
 ---
 
@@ -13,10 +13,23 @@ Spring MVC를 활용하여 방탈출 어드민 페이지를 구성하고,
 * Thymeleaf 템플릿 엔진을 활용하여 화면을 응답한다.
 * `/` 요청 시 어드민 메인 페이지를 응답한다.
 * `/reservation` 요청 시 예약 관리 페이지를 응답한다.
-* `/reservations` 요청 시 예약 목록을 JSON으로 응답한다.
+* 예약 목록을 조회할 수 있다.
+* 새로운 예약을 생성할 수 있다.
+* 기존 예약을 삭제할 수 있다.
 * 별도의 데이터베이스 없이 예약 목록을 관리한다.
 * 예약 조회 응답에는 `id`, `name`, `date`, `time` 정보를 포함한다.
 * 예약 시간은 `HH:mm` 형식으로 응답한다.
+
+---
+
+## 예약 정책
+
+미션 요구사항을 구현하는 과정에서 다음과 같은 예약 정책을 추가로 적용하였다.
+
+* 현재 시각 이전의 예약은 생성할 수 없다.
+* 현재와 같은 분의 예약은 생성할 수 없다.
+* 동일한 이름, 날짜, 시간의 중복 예약은 생성할 수 없다.
+* 존재하지 않는 예약은 삭제할 수 없다.
 
 ---
 
@@ -35,11 +48,33 @@ Spring MVC를 활용하여 방탈출 어드민 페이지를 구성하고,
 
 ### 예약 목록 조회
 
-* [x] `/reservations` 요청 처리
-* [x] 임의의 예약 데이터 관리
+* [x] `GET /reservations` 요청 처리
 * [x] 예약 목록을 JSON 형식으로 응답
 * [x] 예약 도메인 객체와 응답 DTO 분리
 * [x] 예약 시간을 `HH:mm` 형식으로 응답
+
+### 예약 생성
+
+* [x] `POST /reservations` 요청 처리
+* [x] 예약 ID 생성
+* [x] 생성된 예약 정보 응답
+* [x] `201 Created` 응답
+* [x] `Location` 헤더 응답
+* [x] 현재 시각 이전 예약 검증
+* [x] 중복 예약 검증
+
+### 예약 삭제
+
+* [x] `DELETE /reservations/{id}` 요청 처리
+* [x] 예약 ID를 기준으로 삭제
+* [x] 정상 삭제 시 `204 No Content` 응답
+* [x] 존재하지 않는 예약 삭제 검증
+
+### 예외 처리
+
+* [x] 잘못된 예약 요청 시 `400 Bad Request` 응답
+* [x] 존재하지 않는 예약 요청 시 `404 Not Found` 응답
+* [x] 중복 예약 요청 시 `409 Conflict` 응답
 
 ---
 
@@ -58,13 +93,13 @@ Spring MVC를 활용하여 방탈출 어드민 페이지를 구성하고,
   {
     "id": 1,
     "name": "브라운",
-    "date": "2023-01-01",
+    "date": "2026-08-20",
     "time": "10:00"
   },
   {
     "id": 2,
     "name": "브라운",
-    "date": "2023-01-02",
+    "date": "2026-08-21",
     "time": "11:00"
   }
 ]
@@ -72,14 +107,71 @@ Spring MVC를 활용하여 방탈출 어드민 페이지를 구성하고,
 
 ---
 
+### 예약 생성
+
+* Method: `POST`
+* URL: `/reservations`
+* Response: `201 Created`
+
+**Request Body**
+
+```json
+{
+  "name": "브라운",
+  "date": "2026-08-20",
+  "time": "15:40"
+}
+```
+
+**Response Header**
+
+```text
+Location: /reservations/4
+```
+
+**Response Body**
+
+```json
+{
+  "id": 4,
+  "name": "브라운",
+  "date": "2026-08-20",
+  "time": "15:40"
+}
+```
+
+---
+
+### 예약 삭제
+
+* Method: `DELETE`
+* URL: `/reservations/{id}`
+* Response: `204 No Content`
+
+---
+
 ## 주요 객체
 
-| 객체                      | 역할                             |
-| ----------------------- | ------------------------------ |
-| `PageController`  | 어드민 메인 페이지 요청을 처리한다.           |
-| `ReservationController` | 예약 관리 페이지와 예약 목록 조회 요청을 처리한다.  |
-| `Reservation`           | 예약의 식별자, 예약자 이름, 날짜, 시간을 관리한다. |
-| `ReservationResponse`   | 예약 정보를 API 응답 형식으로 전달하는 DTO이다. |
+| 객체 | 역할 |
+| --- | --- |
+| `PageController` | 어드민 페이지 요청을 처리하고 View를 반환한다. |
+| `ReservationController` | 예약 조회, 생성, 삭제 API 요청을 처리한다. |
+| `ReservationService` | 예약 생성 및 삭제 과정의 비즈니스 로직을 처리한다. |
+| `ReservationRepository` | 예약 데이터를 저장, 조회, 삭제한다. |
+| `Reservation` | 예약의 식별자, 예약자 이름, 날짜, 시간을 관리한다. |
+| `ReservationRequest` | 예약 생성 요청 데이터를 전달하는 DTO이다. |
+| `ReservationResponse` | 예약 정보를 API 응답 형식으로 전달하는 DTO이다. |
+| `GlobalExceptionHandler` | 예약 처리 중 발생한 예외를 HTTP 응답으로 변환한다. |
+
+---
+
+## 예외 처리
+
+| 상황 | HTTP Status |
+| --- | --- |
+| 잘못된 예약 요청 | `400 Bad Request` |
+| 존재하지 않는 예약 | `404 Not Found` |
+| 중복 예약 | `409 Conflict` |
 
 ---
 
@@ -89,5 +181,30 @@ Spring MVC를 활용하여 방탈출 어드민 페이지를 구성하고,
 
 * `/` 요청 시 `200 OK` 응답 확인
 * `/reservation` 요청 시 `200 OK` 응답 확인
-* `/reservations` 요청 시 `200 OK` 응답 확인
-* `/reservations` 응답의 예약 목록 개수 확인
+* 예약 목록 조회 확인
+* 예약 생성 시 `201 Created` 응답 확인
+* 예약 삭제 시 `204 No Content` 응답 확인
+
+### ReservationControllerTest
+
+* 예약 목록 조회 확인
+* 예약 시간 `HH:mm` 형식 확인
+* 예약 생성 API 응답 확인
+* 예약 삭제 API 응답 확인
+
+### ReservationServiceTest
+
+* 과거 날짜 예약 검증
+* 현재보다 이전 시간 예약 검증
+* 현재와 같은 분의 예약 검증
+* 현재보다 이후 시간의 예약 생성 확인
+* 중복 예약 검증
+* 존재하는 예약 삭제 확인
+* 존재하지 않는 예약 삭제 검증
+
+### ReservationRepositoryTest
+
+* 예약 목록 조회 확인
+* 예약 저장 확인
+* 동일한 이름, 날짜, 시간의 예약 존재 여부 확인
+* 예약 삭제 확인

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
 }

--- a/src/main/java/roomescape/config/TimeConfig.java
+++ b/src/main/java/roomescape/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package roomescape.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/roomescape/controller/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/controller/GlobalExceptionHandler.java
@@ -1,0 +1,29 @@
+package roomescape.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import roomescape.exception.DuplicateReservationException;
+import roomescape.exception.ReservationNotFoundException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Void> handleIllegalArgumentException(
+            IllegalArgumentException e
+    ) {
+        return ResponseEntity.badRequest().build();
+    }
+
+    @ExceptionHandler(ReservationNotFoundException.class)
+    public ResponseEntity<Void> handleReservationNotFound(ReservationNotFoundException e) {
+        return ResponseEntity.notFound().build();
+    }
+
+    @ExceptionHandler(DuplicateReservationException.class)
+    public ResponseEntity<Void> handleDuplicateReservation(DuplicateReservationException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+}

--- a/src/main/java/roomescape/controller/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/controller/GlobalExceptionHandler.java
@@ -1,11 +1,9 @@
 package roomescape.controller;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import roomescape.exception.DuplicateReservationException;
-import roomescape.exception.ReservationNotFoundException;
+import roomescape.exception.RoomEscapeException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -17,13 +15,8 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest().build();
     }
 
-    @ExceptionHandler(ReservationNotFoundException.class)
-    public ResponseEntity<Void> handleReservationNotFound(ReservationNotFoundException e) {
-        return ResponseEntity.notFound().build();
-    }
-
-    @ExceptionHandler(DuplicateReservationException.class)
-    public ResponseEntity<Void> handleDuplicateReservation(DuplicateReservationException e) {
-        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    @ExceptionHandler(RoomEscapeException.class)
+    public ResponseEntity<Void> handleRoomEscapeException(RoomEscapeException e) {
+        return ResponseEntity.status(e.getStatus()).build();
     }
 }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.RestController;
 import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
-import roomescape.repository.ReservationRepository;
 import roomescape.service.ReservationService;
 
 import java.net.URI;
@@ -19,17 +18,15 @@ import java.util.List;
 @RestController
 public class ReservationController {
 
-    private final ReservationRepository reservationRepository;
     private final ReservationService reservationService;
 
-    public ReservationController(ReservationRepository reservationRepository, ReservationService reservationService) {
-        this.reservationRepository = reservationRepository;
+    public ReservationController(ReservationService reservationService) {
         this.reservationService = reservationService;
     }
 
     @GetMapping("/reservations")
     public List<ReservationResponse> reservations() {
-        List<Reservation> reservations = reservationRepository.findAll();
+        List<Reservation> reservations = reservationService.findAll();
 
         return reservations.stream()
                     .map(ReservationResponse::from)

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -1,7 +1,9 @@
 package roomescape.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -49,5 +51,14 @@ public class ReservationController {
         return ResponseEntity
                 .created(uri)
                 .body(reservationResponse);
+    }
+
+    @DeleteMapping("/reservations/{id}")
+    public ResponseEntity<Void> deleteReservation(@PathVariable Long id) {
+        reservationService.delete(id);
+
+        return ResponseEntity
+                .noContent()
+                .build();
     }
 }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -11,6 +11,7 @@ import roomescape.domain.Reservation;
 import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
 import roomescape.service.ReservationService;
+import jakarta.validation.Valid;
 
 import java.net.URI;
 import java.util.List;
@@ -34,7 +35,7 @@ public class ReservationController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity<ReservationResponse> createReservation(@RequestBody ReservationRequest request) {
+    public ResponseEntity<ReservationResponse> createReservation(@Valid @RequestBody ReservationRequest request) {
         Reservation reservation = reservationService.create(
                 request.name(),
                 request.date(),

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -1,19 +1,28 @@
 package roomescape.controller;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import roomescape.domain.Reservation;
+import roomescape.dto.ReservationRequest;
 import roomescape.dto.ReservationResponse;
 import roomescape.repository.ReservationRepository;
+import roomescape.service.ReservationService;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
 public class ReservationController {
-    private final ReservationRepository reservationRepository;
 
-    public ReservationController(ReservationRepository reservationRepository) {
+    private final ReservationRepository reservationRepository;
+    private final ReservationService reservationService;
+
+    public ReservationController(ReservationRepository reservationRepository, ReservationService reservationService) {
         this.reservationRepository = reservationRepository;
+        this.reservationService = reservationService;
     }
 
     @GetMapping("/reservations")
@@ -23,5 +32,22 @@ public class ReservationController {
         return reservations.stream()
                     .map(ReservationResponse::from)
                     .toList();
+    }
+
+    @PostMapping("/reservations")
+    public ResponseEntity<ReservationResponse> createReservation(@RequestBody ReservationRequest request) {
+        Reservation reservation = reservationService.create(
+                request.name(),
+                request.date(),
+                request.time()
+        );
+
+        ReservationResponse reservationResponse = ReservationResponse.from(reservation);
+
+        URI uri = URI.create("/reservations/" + reservationResponse.id());
+
+        return ResponseEntity
+                .created(uri)
+                .body(reservationResponse);
     }
 }

--- a/src/main/java/roomescape/controller/ReservationController.java
+++ b/src/main/java/roomescape/controller/ReservationController.java
@@ -1,15 +1,14 @@
 package roomescape.controller;
 
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 import roomescape.domain.Reservation;
 import roomescape.dto.ReservationResponse;
 import roomescape.repository.ReservationRepository;
 
 import java.util.List;
 
-@Controller
+@RestController
 public class ReservationController {
     private final ReservationRepository reservationRepository;
 
@@ -17,7 +16,6 @@ public class ReservationController {
         this.reservationRepository = reservationRepository;
     }
 
-    @ResponseBody
     @GetMapping("/reservations")
     public List<ReservationResponse> reservations() {
         List<Reservation> reservations = reservationRepository.findAll();

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -1,31 +1,28 @@
 package roomescape.domain;
 
-import java.time.Clock;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.temporal.ChronoUnit;
 
 public class Reservation {
+
     private final Long id;
     private final String name;
     private final LocalDate date;
     private final LocalTime time;
 
     public Reservation(Long id, String name, LocalDate date, LocalTime time) {
-        this(id, name, date, time, Clock.systemDefaultZone());
-    }
-
-    Reservation(Long id, String name, LocalDate date, LocalTime time, Clock clock) {
         validateName(name);
         validateDate(date);
         validateTime(time);
-        validateReservationDateTime(date, time, clock);
 
         this.id = id;
         this.name = name;
         this.date = date;
         this.time = time;
+    }
+
+    public Reservation(String name, LocalDate date, LocalTime time) {
+        this(null, name, date, time);
     }
 
     public Long getId() {
@@ -59,15 +56,6 @@ public class Reservation {
     private void validateTime(LocalTime time) {
         if (time == null) {
             throw new IllegalArgumentException("시간은 비어있을 수 없습니다.");
-        }
-    }
-
-    private void validateReservationDateTime(LocalDate date, LocalTime time, Clock clock) {
-        LocalDateTime reservationDateTime = LocalDateTime.of(date, time).truncatedTo(ChronoUnit.MINUTES);
-        LocalDateTime now = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
-
-        if (!reservationDateTime.isAfter(now)) {
-            throw new IllegalArgumentException("예약은 현재 시각 이후여야 합니다.");
         }
     }
 }

--- a/src/main/java/roomescape/domain/Reservation.java
+++ b/src/main/java/roomescape/domain/Reservation.java
@@ -1,7 +1,10 @@
 package roomescape.domain;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 
 public class Reservation {
     private final Long id;
@@ -10,9 +13,14 @@ public class Reservation {
     private final LocalTime time;
 
     public Reservation(Long id, String name, LocalDate date, LocalTime time) {
+        this(id, name, date, time, Clock.systemDefaultZone());
+    }
+
+    Reservation(Long id, String name, LocalDate date, LocalTime time, Clock clock) {
         validateName(name);
         validateDate(date);
         validateTime(time);
+        validateReservationDateTime(date, time, clock);
 
         this.id = id;
         this.name = name;
@@ -51,6 +59,15 @@ public class Reservation {
     private void validateTime(LocalTime time) {
         if (time == null) {
             throw new IllegalArgumentException("시간은 비어있을 수 없습니다.");
+        }
+    }
+
+    private void validateReservationDateTime(LocalDate date, LocalTime time, Clock clock) {
+        LocalDateTime reservationDateTime = LocalDateTime.of(date, time).truncatedTo(ChronoUnit.MINUTES);
+        LocalDateTime now = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
+
+        if (!reservationDateTime.isAfter(now)) {
+            throw new IllegalArgumentException("예약은 현재 시각 이후여야 합니다.");
         }
     }
 }

--- a/src/main/java/roomescape/dto/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/ReservationRequest.java
@@ -1,0 +1,13 @@
+package roomescape.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record ReservationRequest(
+        String name,
+        LocalDate date,
+        @JsonFormat(pattern = "HH:mm") LocalTime time
+) {
+}

--- a/src/main/java/roomescape/dto/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/ReservationRequest.java
@@ -2,12 +2,16 @@ package roomescape.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 public record ReservationRequest(
-        String name,
-        LocalDate date,
+        @NotBlank String name,
+        @NotNull LocalDate date,
+        @NotNull
         @JsonFormat(pattern = "HH:mm") LocalTime time
 ) {
 }

--- a/src/main/java/roomescape/exception/DuplicateReservationException.java
+++ b/src/main/java/roomescape/exception/DuplicateReservationException.java
@@ -1,0 +1,8 @@
+package roomescape.exception;
+
+public class DuplicateReservationException extends RuntimeException {
+
+    public DuplicateReservationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/exception/DuplicateReservationException.java
+++ b/src/main/java/roomescape/exception/DuplicateReservationException.java
@@ -1,8 +1,10 @@
 package roomescape.exception;
 
-public class DuplicateReservationException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class DuplicateReservationException extends RoomEscapeException {
 
     public DuplicateReservationException(String message) {
-        super(message);
+        super(message, HttpStatus.CONFLICT);
     }
 }

--- a/src/main/java/roomescape/exception/ReservationNotFoundException.java
+++ b/src/main/java/roomescape/exception/ReservationNotFoundException.java
@@ -1,8 +1,10 @@
 package roomescape.exception;
 
-public class ReservationNotFoundException extends RuntimeException {
+import org.springframework.http.HttpStatus;
+
+public class ReservationNotFoundException extends RoomEscapeException {
 
     public ReservationNotFoundException(String message) {
-        super(message);
+        super(message, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/roomescape/exception/ReservationNotFoundException.java
+++ b/src/main/java/roomescape/exception/ReservationNotFoundException.java
@@ -1,0 +1,8 @@
+package roomescape.exception;
+
+public class ReservationNotFoundException extends RuntimeException {
+
+    public ReservationNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/roomescape/exception/RoomEscapeException.java
+++ b/src/main/java/roomescape/exception/RoomEscapeException.java
@@ -1,0 +1,17 @@
+package roomescape.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class RoomEscapeException extends RuntimeException {
+
+    private final HttpStatus status;
+
+    protected RoomEscapeException(String message, HttpStatus status) {
+        super(message);
+        this.status = status;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -10,9 +10,9 @@ import java.util.List;
 @Repository
 public class ReservationRepository {
     private final List<Reservation> reservations = List.of(
-            new Reservation(1L, "브라운", LocalDate.of(2023, 1, 1), LocalTime.of(10, 0)),
-            new Reservation(2L, "브라운", LocalDate.of(2023, 1, 2), LocalTime.of(11, 0)),
-            new Reservation(3L, "브라운", LocalDate.of(2023, 1, 3), LocalTime.of(12, 0))
+            new Reservation(1L, "브라운", LocalDate.now().plusDays(1), LocalTime.of(10, 0)),
+            new Reservation(2L, "브라운", LocalDate.now().plusDays(2), LocalTime.of(11, 0)),
+            new Reservation(3L, "브라운", LocalDate.now().plusDays(3), LocalTime.of(12, 0))
     );
 
     public List<Reservation> findAll() {

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -5,17 +5,44 @@ import roomescape.domain.Reservation;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Repository
 public class ReservationRepository {
-    private final List<Reservation> reservations = List.of(
+
+    private final List<Reservation> reservations = new ArrayList<>(List.of(
             new Reservation(1L, "브라운", LocalDate.now().plusDays(1), LocalTime.of(10, 0)),
             new Reservation(2L, "브라운", LocalDate.now().plusDays(2), LocalTime.of(11, 0)),
             new Reservation(3L, "브라운", LocalDate.now().plusDays(3), LocalTime.of(12, 0))
-    );
+    ));
+
+    private final AtomicLong index = new AtomicLong(4L);
 
     public List<Reservation> findAll() {
-        return reservations;
+        return List.copyOf(reservations);
+    }
+
+    public Reservation save(Reservation reservation) {
+        Reservation savedReservation = new Reservation(
+                index.getAndIncrement(),
+                reservation.getName(),
+                reservation.getDate(),
+                reservation.getTime()
+        );
+
+        reservations.add(savedReservation);
+
+        return savedReservation;
+    }
+
+    public boolean existsByNameAndDateAndTime(String name, LocalDate date, LocalTime time) {
+        return reservations.stream()
+                .anyMatch(reservation ->
+                        reservation.getName().equals(name)
+                                && reservation.getDate().equals(date)
+                                && reservation.getTime().equals(time)
+                );
     }
 }

--- a/src/main/java/roomescape/repository/ReservationRepository.java
+++ b/src/main/java/roomescape/repository/ReservationRepository.java
@@ -37,6 +37,10 @@ public class ReservationRepository {
         return savedReservation;
     }
 
+    public boolean deleteById(Long id) {
+        return reservations.removeIf(reservation -> reservation.getId().equals(id));
+    }
+
     public boolean existsByNameAndDateAndTime(String name, LocalDate date, LocalTime time) {
         return reservations.stream()
                 .anyMatch(reservation ->

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -3,6 +3,8 @@ package roomescape.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import roomescape.domain.Reservation;
+import roomescape.exception.DuplicateReservationException;
+import roomescape.exception.ReservationNotFoundException;
 import roomescape.repository.ReservationRepository;
 
 import java.time.Clock;
@@ -38,7 +40,7 @@ public class ReservationService {
 
     public void delete(Long id) {
         if (!reservationRepository.deleteById(id)) {
-            throw new IllegalArgumentException("존재하지 않는 예약입니다.");
+            throw new ReservationNotFoundException("존재하지 않는 예약입니다.");
         }
     }
 
@@ -55,7 +57,7 @@ public class ReservationService {
         boolean exists = reservationRepository.existsByNameAndDateAndTime(name, date, time);
 
         if (exists) {
-            throw new IllegalArgumentException("이미 존재하는 예약입니다.");
+            throw new DuplicateReservationException("이미 존재하는 예약입니다.");
         }
     }
 }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -35,10 +35,10 @@ public class ReservationService {
     }
 
     public Reservation create(String name, LocalDate date, LocalTime time) {
-        Reservation reservation = new Reservation(name, date, time);
-
         validateReservationDateTime(date, time);
         validateDuplicateReservation(name, date, time);
+
+        Reservation reservation = new Reservation(name, date, time);
 
         return reservationRepository.save(reservation);
     }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -1,0 +1,55 @@
+package roomescape.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import roomescape.domain.Reservation;
+import roomescape.repository.ReservationRepository;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+
+@Service
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final Clock clock;
+
+    @Autowired
+    public ReservationService(ReservationRepository reservationRepository) {
+        this(reservationRepository, Clock.systemDefaultZone());
+    }
+
+    ReservationService(ReservationRepository reservationRepository, Clock clock) {
+        this.reservationRepository = reservationRepository;
+        this.clock = clock;
+    }
+
+    public Reservation create(String name, LocalDate date, LocalTime time) {
+        Reservation reservation = new Reservation(name, date, time);
+
+        validateReservationDateTime(date, time);
+        validateDuplicateReservation(name, date, time);
+
+        return reservationRepository.save(reservation);
+    }
+
+    private void validateReservationDateTime(LocalDate date, LocalTime time) {
+        LocalDateTime reservationDateTime = LocalDateTime.of(date, time).truncatedTo(ChronoUnit.MINUTES);
+        LocalDateTime now = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
+
+        if (!reservationDateTime.isAfter(now)) {
+            throw new IllegalArgumentException("예약은 현재 시각 이후여야 합니다.");
+        }
+    }
+
+    private void validateDuplicateReservation(String name, LocalDate date, LocalTime time) {
+        boolean exists = reservationRepository.existsByNameAndDateAndTime(name, date, time);
+
+        if (exists) {
+            throw new IllegalArgumentException("이미 존재하는 예약입니다.");
+        }
+    }
+}

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -1,6 +1,5 @@
 package roomescape.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import roomescape.domain.Reservation;
 import roomescape.exception.DuplicateReservationException;
@@ -19,11 +18,6 @@ public class ReservationService {
 
     private final ReservationRepository reservationRepository;
     private final Clock clock;
-
-    @Autowired
-    public ReservationService(ReservationRepository reservationRepository) {
-        this(reservationRepository, Clock.systemDefaultZone());
-    }
 
     ReservationService(ReservationRepository reservationRepository, Clock clock) {
         this.reservationRepository = reservationRepository;

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -12,6 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 @Service
 public class ReservationService {
@@ -27,6 +28,10 @@ public class ReservationService {
     ReservationService(ReservationRepository reservationRepository, Clock clock) {
         this.reservationRepository = reservationRepository;
         this.clock = clock;
+    }
+
+    public List<Reservation> findAll() {
+        return reservationRepository.findAll();
     }
 
     public Reservation create(String name, LocalDate date, LocalTime time) {

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -59,9 +59,9 @@ public class ReservationService {
     }
 
     private void validateDuplicateReservation(String name, LocalDate date, LocalTime time) {
-        boolean exists = reservationRepository.existsByNameAndDateAndTime(name, date, time);
+        boolean isDuplicate = reservationRepository.existsByNameAndDateAndTime(name, date, time);
 
-        if (exists) {
+        if (isDuplicate) {
             throw new DuplicateReservationException("이미 존재하는 예약입니다.");
         }
     }

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -36,6 +36,12 @@ public class ReservationService {
         return reservationRepository.save(reservation);
     }
 
+    public void delete(Long id) {
+        if (!reservationRepository.deleteById(id)) {
+            throw new IllegalArgumentException("존재하지 않는 예약입니다.");
+        }
+    }
+
     private void validateReservationDateTime(LocalDate date, LocalTime time) {
         LocalDateTime reservationDateTime = LocalDateTime.of(date, time).truncatedTo(ChronoUnit.MINUTES);
         LocalDateTime now = LocalDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -3,17 +3,26 @@ package roomescape;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.config.FixedClockConfig;
 
+import java.time.Clock;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 
+@Import(FixedClockConfig.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 public class MissionStepTest {
+
+    @Autowired
+    private Clock clock;
 
     @Test
     void 일단계() {
@@ -40,8 +49,10 @@ public class MissionStepTest {
     @Test
     void 삼단계() {
         Map<String, String> params = new HashMap<>();
+        LocalDate reservationDate = LocalDate.now(clock).plusDays(1);
+
         params.put("name", "브라운");
-        params.put("date", "2027-08-05");
+        params.put("date", reservationDate.toString());
         params.put("time", "15:40");
 
         RestAssured.given().log().all()

--- a/src/test/java/roomescape/MissionStepTest.java
+++ b/src/test/java/roomescape/MissionStepTest.java
@@ -1,9 +1,13 @@
 package roomescape;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 
@@ -31,5 +35,61 @@ public class MissionStepTest {
                 .then().log().all()
                 .statusCode(200)
                 .body("size()", is(3));
+    }
+
+    @Test
+    void 삼단계() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "2027-08-05");
+        params.put("time", "15:40");
+
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(201)
+                .header("Location", "/reservations/4")
+                .body("id", is(4));
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(4));
+
+        RestAssured.given().log().all()
+                .when().delete("/reservations/1")
+                .then().log().all()
+                .statusCode(204);
+
+        RestAssured.given().log().all()
+                .when().get("/reservations")
+                .then().log().all()
+                .statusCode(200)
+                .body("size()", is(3));
+    }
+
+    @Test
+    void 사단계() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", "");
+        params.put("time", "");
+
+        // 필요한 인자가 없는 경우
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/reservations")
+                .then().log().all()
+                .statusCode(400);
+
+        // 삭제할 예약이 없는 경우
+        RestAssured.given().log().all()
+                .when().delete("/reservations/999")
+                .then().log().all()
+                .statusCode(404);
     }
 }

--- a/src/test/java/roomescape/config/FixedClockConfig.java
+++ b/src/test/java/roomescape/config/FixedClockConfig.java
@@ -1,0 +1,24 @@
+package roomescape.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@TestConfiguration
+public class FixedClockConfig {
+
+    @Bean
+    @Primary
+    Clock fixedClock() {
+        return Clock.fixed(
+                LocalDateTime.of(2026, 1, 1, 10, 0)
+                        .atZone(ZoneId.of("Asia/Seoul"))
+                        .toInstant(),
+                ZoneId.of("Asia/Seoul")
+        );
+    }
+}

--- a/src/test/java/roomescape/controller/ReservationControllerTest.java
+++ b/src/test/java/roomescape/controller/ReservationControllerTest.java
@@ -1,16 +1,25 @@
 package roomescape.controller;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 @SpringBootTest(
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@DirtiesContext(
+        classMode =  DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD
 )
 public class ReservationControllerTest {
 
@@ -38,6 +47,38 @@ public class ReservationControllerTest {
                 .when()
                 .get("/reservations")
                 .then()
+                .statusCode(200)
                 .body("[0].time", is("10:00"));
+    }
+
+    @Test
+    void 예약을_추가할_수_있다() {
+        String date = LocalDate.now().plusDays(1).toString();
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "브라운");
+        params.put("date", date);
+        params.put("time", "12:00");
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when()
+                .post("/reservations")
+                .then()
+                .statusCode(201)
+                .header("Location", "/reservations/4")
+                .body("id", is(4))
+                .body("name", is("브라운"))
+                .body("date", is(date))
+                .body("time", is("12:00"));
+    }
+
+    @Test
+    void 예약을_삭제할_수_있다() {
+        given()
+                .when()
+                .delete("/reservations/1")
+                .then()
+                .statusCode(204);
     }
 }

--- a/src/test/java/roomescape/domain/ReservationTest.java
+++ b/src/test/java/roomescape/domain/ReservationTest.java
@@ -5,27 +5,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.time.Clock;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.ZoneId;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ReservationTest {
-
-    private static final LocalDate TODAY = LocalDate.of(2023, 1, 2);
-    private static final LocalTime NOW = LocalTime.of(10, 30);
-    private static final LocalDate FUTURE_DATE = TODAY.plusDays(1);
-
-    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
-
-    private static final Clock FIXED_CLOCK = Clock.fixed(
-            LocalDateTime.of(TODAY, NOW).atZone(ZONE_ID).toInstant(),
-            ZONE_ID
-    );
 
     @ParameterizedTest
     @NullAndEmptySource
@@ -36,9 +21,8 @@ public class ReservationTest {
                 () -> new Reservation(
                         1L,
                         name,
-                        FUTURE_DATE,
-                        LocalTime.of(10, 0),
-                        FIXED_CLOCK
+                        LocalDate.of(2023,1,1),
+                        LocalTime.of(10, 0)
                 )
         );
     }
@@ -51,8 +35,7 @@ public class ReservationTest {
                         1L,
                         "브라운",
                         null,
-                        LocalTime.of(10, 0),
-                        FIXED_CLOCK
+                        LocalTime.of(10, 0)
                 )
         );
     }
@@ -64,64 +47,8 @@ public class ReservationTest {
                 () -> new Reservation(
                         1L,
                         "브라운",
-                        FUTURE_DATE,
-                        null,
-                        FIXED_CLOCK
-                )
-        );
-    }
-
-    @Test
-    void 과거_날짜로_예약하면_예외가_발생한다() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> new Reservation(
-                        1L,
-                        "브라운",
-                        TODAY.minusDays(1),
-                        NOW,
-                        FIXED_CLOCK
-                )
-        );
-    }
-
-    @Test
-    void 오늘_현재보다_이전_시간으로_예약하면_예외가_발생한다() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> new Reservation(
-                        1L,
-                        "브라운",
-                        TODAY,
-                        NOW.minusMinutes(1),
-                        FIXED_CLOCK
-                )
-        );
-    }
-
-    @Test
-    void 현재와_같은_분으로_예약하면_예외가_발생한다() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> new Reservation(
-                        1L,
-                        "브라운",
-                        TODAY,
-                        NOW,
-                        FIXED_CLOCK
-                )
-        );
-    }
-
-    @Test
-    void 현재보다_이후_시간으로_예약할_수_있다() {
-        assertDoesNotThrow(
-                () -> new Reservation(
-                        1L,
-                        "브라운",
-                        TODAY,
-                        NOW.plusMinutes(1),
-                        FIXED_CLOCK
+                        LocalDate.of(2023,1,1),
+                        null
                 )
         );
     }

--- a/src/test/java/roomescape/domain/ReservationTest.java
+++ b/src/test/java/roomescape/domain/ReservationTest.java
@@ -5,23 +5,27 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ReservationTest {
 
-    @Test
-    void 유효한_예약을_생성할_수_있다() {
-        assertDoesNotThrow(() -> new Reservation(
-                1L,
-                "브라운",
-                LocalDate.of(2023, 1, 1),
-                LocalTime.of(10, 0))
-        );
-    }
+    private static final LocalDate TODAY = LocalDate.of(2023, 1, 2);
+    private static final LocalTime NOW = LocalTime.of(10, 30);
+    private static final LocalDate FUTURE_DATE = TODAY.plusDays(1);
+
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            LocalDateTime.of(TODAY, NOW).atZone(ZONE_ID).toInstant(),
+            ZONE_ID
+    );
 
     @ParameterizedTest
     @NullAndEmptySource
@@ -32,8 +36,10 @@ public class ReservationTest {
                 () -> new Reservation(
                         1L,
                         name,
-                        LocalDate.of(2023, 1, 1),
-                        LocalTime.of(10, 0))
+                        FUTURE_DATE,
+                        LocalTime.of(10, 0),
+                        FIXED_CLOCK
+                )
         );
     }
 
@@ -45,7 +51,9 @@ public class ReservationTest {
                         1L,
                         "브라운",
                         null,
-                        LocalTime.of(10, 0))
+                        LocalTime.of(10, 0),
+                        FIXED_CLOCK
+                )
         );
     }
 
@@ -56,8 +64,65 @@ public class ReservationTest {
                 () -> new Reservation(
                         1L,
                         "브라운",
-                        LocalDate.of(2023, 1, 1),
-                        null)
+                        FUTURE_DATE,
+                        null,
+                        FIXED_CLOCK
+                )
+        );
+    }
+
+    @Test
+    void 과거_날짜로_예약하면_예외가_발생한다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new Reservation(
+                        1L,
+                        "브라운",
+                        TODAY.minusDays(1),
+                        NOW,
+                        FIXED_CLOCK
+                )
+        );
+    }
+
+    @Test
+    void 오늘_현재보다_이전_시간으로_예약하면_예외가_발생한다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new Reservation(
+                        1L,
+                        "브라운",
+                        TODAY,
+                        NOW.minusMinutes(1),
+                        FIXED_CLOCK
+                )
+        );
+    }
+
+    @Test
+    void 현재와_같은_분으로_예약하면_예외가_발생한다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new Reservation(
+                        1L,
+                        "브라운",
+                        TODAY,
+                        NOW,
+                        FIXED_CLOCK
+                )
+        );
+    }
+
+    @Test
+    void 현재보다_이후_시간으로_예약할_수_있다() {
+        assertDoesNotThrow(
+                () -> new Reservation(
+                        1L,
+                        "브라운",
+                        TODAY,
+                        NOW.plusMinutes(1),
+                        FIXED_CLOCK
+                )
         );
     }
 }

--- a/src/test/java/roomescape/repository/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/repository/ReservationRepositoryTest.java
@@ -17,11 +17,13 @@ public class ReservationRepositoryTest {
     private static final LocalDate TODAY = LocalDate.of(2023, 1, 2);
     private static final LocalTime NOW = LocalTime.of(10, 30);
 
-    private final ReservationRepository repository = new ReservationRepository();
+    private static final Long NON_EXISTENT_ID = 999L;
+
+    private final ReservationRepository reservationRepository = new ReservationRepository();
 
     @Test
     void 저장된_예약_목록을_조회할_수_있다() {
-        List<Reservation> reservations = repository.findAll();
+        List<Reservation> reservations = reservationRepository.findAll();
         Reservation first = reservations.get(0);
 
         assertEquals(3, reservations.size());
@@ -33,7 +35,7 @@ public class ReservationRepositoryTest {
     @Test
     void 예약을_저장할_수_있다() {
         Reservation reservation = new Reservation(NAME, TODAY, NOW);
-        Reservation savedReservation = repository.save(reservation);
+        Reservation savedReservation = reservationRepository.save(reservation);
 
         assertEquals(4L, savedReservation.getId());
         assertEquals(NAME, savedReservation.getName());
@@ -44,9 +46,9 @@ public class ReservationRepositoryTest {
     @Test
     void 동일한_이름_날짜_시간의_예약이_존재하면_true를_반환한다() {
         Reservation reservation = new Reservation(NAME, TODAY, NOW);
-        Reservation savedReservation = repository.save(reservation);
+        Reservation savedReservation = reservationRepository.save(reservation);
 
-        assertTrue(repository.existsByNameAndDateAndTime(
+        assertTrue(reservationRepository.existsByNameAndDateAndTime(
                 NAME,
                 TODAY,
                 NOW
@@ -56,12 +58,28 @@ public class ReservationRepositoryTest {
     @Test
     void 동일한_이름_날짜_시간의_예약이_없으면_false를_반환한다() {
         Reservation reservation = new Reservation(NAME, TODAY, NOW);
-        Reservation savedReservation = repository.save(reservation);
+        Reservation savedReservation = reservationRepository.save(reservation);
 
-        assertFalse(repository.existsByNameAndDateAndTime(
+        assertFalse(reservationRepository.existsByNameAndDateAndTime(
                 NAME,
                 TODAY,
                 NOW.plusMinutes(1)
         ));
+    }
+
+    @Test
+    void 존재하는_예약_id로_삭제하면_true를_반환한다() {
+        LocalTime reservationTime = NOW.plusHours(2);
+
+        Reservation reservation = new Reservation(NAME, TODAY, reservationTime);
+        Reservation savedReservation = reservationRepository.save(reservation);
+        Long id = savedReservation.getId();
+
+        assertTrue(reservationRepository.deleteById(id));
+    }
+
+    @Test
+    void 존재하지_않는_예약_id로_삭제하면_false를_반환한다() {
+        assertFalse(reservationRepository.deleteById(NON_EXISTENT_ID));
     }
 }

--- a/src/test/java/roomescape/repository/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/repository/ReservationRepositoryTest.java
@@ -3,16 +3,24 @@ package roomescape.repository;
 import org.junit.jupiter.api.Test;
 import roomescape.domain.Reservation;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ReservationRepositoryTest {
 
+    private static final String NAME = "브라운";
+    private static final LocalDate TODAY = LocalDate.of(2023, 1, 2);
+    private static final LocalTime NOW = LocalTime.of(10, 30);
+
+    private final ReservationRepository repository = new ReservationRepository();
+
     @Test
     void 저장된_예약_목록을_조회할_수_있다() {
-        ReservationRepository repository = new ReservationRepository();
         List<Reservation> reservations = repository.findAll();
         Reservation first = reservations.get(0);
 
@@ -20,5 +28,40 @@ public class ReservationRepositoryTest {
         assertEquals(1L, first.getId());
         assertEquals("브라운", first.getName());
         assertEquals(LocalTime.of(10, 0), first.getTime());
+    }
+
+    @Test
+    void 예약을_저장할_수_있다() {
+        Reservation reservation = new Reservation(NAME, TODAY, NOW);
+        Reservation savedReservation = repository.save(reservation);
+
+        assertEquals(4L, savedReservation.getId());
+        assertEquals(NAME, savedReservation.getName());
+        assertEquals(TODAY, savedReservation.getDate());
+        assertEquals(NOW, savedReservation.getTime());
+    }
+
+    @Test
+    void 동일한_이름_날짜_시간의_예약이_존재하면_true를_반환한다() {
+        Reservation reservation = new Reservation(NAME, TODAY, NOW);
+        Reservation savedReservation = repository.save(reservation);
+
+        assertTrue(repository.existsByNameAndDateAndTime(
+                NAME,
+                TODAY,
+                NOW
+        ));
+    }
+
+    @Test
+    void 동일한_이름_날짜_시간의_예약이_없으면_false를_반환한다() {
+        Reservation reservation = new Reservation(NAME, TODAY, NOW);
+        Reservation savedReservation = repository.save(reservation);
+
+        assertFalse(repository.existsByNameAndDateAndTime(
+                NAME,
+                TODAY,
+                NOW.plusMinutes(1)
+        ));
     }
 }

--- a/src/test/java/roomescape/repository/ReservationRepositoryTest.java
+++ b/src/test/java/roomescape/repository/ReservationRepositoryTest.java
@@ -1,0 +1,24 @@
+package roomescape.repository;
+
+import org.junit.jupiter.api.Test;
+import roomescape.domain.Reservation;
+
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ReservationRepositoryTest {
+
+    @Test
+    void 저장된_예약_목록을_조회할_수_있다() {
+        ReservationRepository repository = new ReservationRepository();
+        List<Reservation> reservations = repository.findAll();
+        Reservation first = reservations.get(0);
+
+        assertEquals(3, reservations.size());
+        assertEquals(1L, first.getId());
+        assertEquals("브라운", first.getName());
+        assertEquals(LocalTime.of(10, 0), first.getTime());
+    }
+}

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -113,10 +113,10 @@ public class ReservationServiceTest {
 
         reservationService.delete(id);
 
-        boolean exists = reservationRepository.findAll().stream()
+        boolean reservationExists = reservationRepository.findAll().stream()
                 .anyMatch(reservation -> reservation.getId().equals(id));
 
-        assertFalse(exists);
+        assertFalse(reservationExists);
     }
 
     @Test

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -14,6 +14,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class ReservationServiceTest {
@@ -110,9 +111,12 @@ public class ReservationServiceTest {
         Reservation savedReservation = reservationService.create(NAME, TODAY, reservationTime);
         Long id = savedReservation.getId();
 
-        assertDoesNotThrow(
-                () -> reservationService.delete(id)
-        );
+        reservationService.delete(id);
+
+        boolean exists = reservationRepository.findAll().stream()
+                .anyMatch(reservation -> reservation.getId().equals(id));
+
+        assertFalse(exists);
     }
 
     @Test

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -3,6 +3,8 @@ package roomescape.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import roomescape.domain.Reservation;
+import roomescape.exception.DuplicateReservationException;
+import roomescape.exception.ReservationNotFoundException;
 import roomescape.repository.ReservationRepository;
 
 import java.time.Clock;
@@ -92,7 +94,7 @@ public class ReservationServiceTest {
         reservationService.create(NAME, TODAY, reservationTime);
 
         assertThrows(
-                IllegalArgumentException.class,
+                DuplicateReservationException.class,
                 () -> reservationService.create(
                         NAME,
                         TODAY,
@@ -116,7 +118,7 @@ public class ReservationServiceTest {
     @Test
     void 존재하지_않는_예약을_삭제하면_예외가_발생한다() {
         assertThrows(
-                IllegalArgumentException.class,
+                ReservationNotFoundException.class,
                 () -> reservationService.delete(NON_EXISTENT_ID)
         );
     }

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -1,0 +1,100 @@
+package roomescape.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import roomescape.repository.ReservationRepository;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ReservationServiceTest {
+
+    private static final String NAME = "브라운";
+    private static final LocalDate TODAY = LocalDate.of(2023, 1, 2);
+    private static final LocalTime NOW = LocalTime.of(10, 30);
+
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            LocalDateTime.of(TODAY, NOW).atZone(ZONE_ID).toInstant(),
+            ZONE_ID
+    );
+
+    private ReservationRepository reservationRepository;
+    private ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationRepository = new ReservationRepository();
+        reservationService = new ReservationService(reservationRepository, FIXED_CLOCK);
+    }
+
+    @Test
+    void 과거_날짜로_예약하면_예외가_발생한다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> reservationService.create(
+                        NAME,
+                        TODAY.minusDays(1),
+                        NOW
+                )
+        );
+    }
+
+    @Test
+    void 오늘_현재보다_이전_시간으로_예약하면_예외가_발생한다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> reservationService.create(
+                        NAME,
+                        TODAY,
+                        NOW.minusMinutes(1)
+                )
+        );
+    }
+
+    @Test
+    void 현재와_같은_분으로_예약하면_예외가_발생한다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> reservationService.create(
+                        NAME,
+                        TODAY,
+                        NOW
+                )
+        );
+    }
+
+    @Test
+    void 현재보다_이후_시간으로_예약할_수_있다() {
+        assertDoesNotThrow(
+                () -> reservationService.create(
+                        NAME,
+                        TODAY,
+                        NOW.plusMinutes(1)
+                )
+        );
+    }
+
+    @Test
+    void 중복_예약을_생성하면_예외가_발생한다() {
+        LocalTime reservationTime = NOW.plusHours(2);
+
+        reservationService.create(NAME, TODAY, reservationTime);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> reservationService.create(
+                        NAME,
+                        TODAY,
+                        reservationTime
+                )
+        );
+    }
+}

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -2,6 +2,7 @@ package roomescape.service;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import roomescape.domain.Reservation;
 import roomescape.repository.ReservationRepository;
 
 import java.time.Clock;
@@ -18,6 +19,8 @@ public class ReservationServiceTest {
     private static final String NAME = "브라운";
     private static final LocalDate TODAY = LocalDate.of(2023, 1, 2);
     private static final LocalTime NOW = LocalTime.of(10, 30);
+
+    private static final Long NON_EXISTENT_ID = 999L;
 
     private static final ZoneId ZONE_ID = ZoneId.of("Asia/Seoul");
 
@@ -95,6 +98,26 @@ public class ReservationServiceTest {
                         TODAY,
                         reservationTime
                 )
+        );
+    }
+
+    @Test
+    void 존재하는_예약을_삭제할_수_있다() {
+        LocalTime reservationTime = NOW.plusHours(2);
+
+        Reservation savedReservation = reservationService.create(NAME, TODAY, reservationTime);
+        Long id = savedReservation.getId();
+
+        assertDoesNotThrow(
+                () -> reservationService.delete(id)
+        );
+    }
+
+    @Test
+    void 존재하지_않는_예약을_삭제하면_예외가_발생한다() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> reservationService.delete(NON_EXISTENT_ID)
         );
     }
 }

--- a/src/test/java/roomescape/service/ReservationServiceTest.java
+++ b/src/test/java/roomescape/service/ReservationServiceTest.java
@@ -66,7 +66,7 @@ public class ReservationServiceTest {
     }
 
     @Test
-    void 현재와_같은_분으로_예약하면_예외가_발생한다() {
+    void 현재_시각과_동일한_시각의_예약은_생성할_수_없다() {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> reservationService.create(


### PR DESCRIPTION
안녕하세요, 임혜정 리뷰어님. 완두콩 스터디원으로 참여하고 있는 조하은입니다.
이번 미션도 잘 부탁드립니다!

## 현재 학습 상황

Spring 프로젝트를 약 2번 정도 진행한 경험이 있어 기본적인 프로젝트 구조와 요청이 처리되는 흐름을 접해본 적은 있습니다. 다만 당시에는 코드 구현 과정에서 AI의 도움을 많이 받았기 때문에 스스로 요구사항을 보고 직접 구조를 고민하고 코드를 설계하는 경험은 아직 부족합니다. 

## 이번 미션에서 어려웠던 부분

### 1. 예약 생성 흐름에서 각 계층의 책임

이번 미션에서는 예약 추가 기능을 구현하면서 `Request`로 전달받은 값이 실제 예약으로 저장되기까지 Controller, Service, Repository가 각각 어떤 책임을 가져야 하는지 정리하는 부분에서 시간이 조금 걸렸습니다.

처음에는 Controller에서 Repository를 직접 이용하여 저장하는 방법도 생각했지만, 현재 시각 검증이나 중복 예약 검증과 같은 규칙이 생기면서 단순 데이터 저장과 예약 추가 과정에서의 검증을 분리할 필요가 있다고 생각하였습니다.

이에 현재는 다음과 같이 책임을 나누어 보았습니다.

- `Controller`: HTTP 요청을 받고 요청 값을 Service에 전달하며 처리 결과를 HTTP 응답으로 변환
- `Service`: 예약 조회, 생성, 삭제와 같은 기능의 흐름을 담당하고 필요한 비즈니스 규칙을 검증
- `Repository`: 예약 데이터의 조회, 저장, 삭제와 식별자 관리
- `Reservation`: 이름, 날짜, 시간처럼 예약 객체 자체가 가져야 하는 기본적인 유효성 검증

처음에는 별도의 비즈니스 로직이 없는 예약 목록 조회의 경우 Controller에서 Repository를 직접 사용하도록 두었습니다. 그러나 Controller가 데이터 저장 방식까지 알 필요는 없을 것 같아, 조회 역시 Service에 요청하도록 변경하여 Controller는 예약과 관련된 요청을 Service에 전달하는 역할에 집중하도록 구성하였습니다.

### 2. 현재 시간 검증과 `Clock`

이전 리뷰에서 말씀해주신 현재보다 이전 시간의 예약 요청을 검증하면서 시간에 의존하는 로직을 어떻게 테스트해야 할지도 고민해보았습니다. 만약 `LocalDateTime.now()`를 직접 사용하면 테스트 실행 시각에 따라 결과가 달라질 수 있다는 문제가 있었습니다.

이 과정에서 현재 시간의 기준을 객체로 전달할 수 있는 `Clock`을 알게 되었고, 이를 통해 실제 실행에서는 `Clock.systemDefaultZone()`, 테스트에서는 `Clock.fixed()`를 사용하여 원하는 시각을 기준으로 테스트할 수 있도록 구현하였습니다.

현재 시각 검증의 책임을 어디에 둘지도 고민해보았는데 기존에는 Reservation에 두었지만, 중복 예약 검증을 추가하며 비즈니스 관련 로직은 Service에 작성하는 것이 좋을 것 같다고 판단하였습니다.

이에 이름, 날짜, 시간이 비어 있지 않아야 하는 것처럼 `예약 객체 자체가 항상 만족해야 하는 조건`은 `Reservation`에서 검증하고, `새로운 예약은 현재보다 이후여야 한다`는 생성 시점의 정책은 `ReservationService`에서 검증하도록 분리하였습니다.


## 리뷰에서 중점적으로 봐주셨으면 하는 부분

### 1. Controller, Service, Repository의 책임 분리

위와 같이 Controller는 요청과 응답, Service는 예약 기능의 흐름과 비즈니스 규칙, Repository는 데이터 관리를 담당하도록 나누어 보았습니다.

다만 현재 조회 메서드의 경우 Service가 Repository의 `findAll()`을 그대로 호출하는 정도의 단순한 위임만 하고 있어 이런 경우에도 Service를 거치는 것이 적절한지 궁금합니다.

또한 예약을 저장하기 전에는 `id`가 없는 `Reservation` 객체를 생성하고, Repository에서 저장할 때 식별자를 부여한 새로운 `Reservation` 객체를 만들어 반환하도록 구현하였습니다.

그러나 이처럼 구현하면서 하나의 예약을 저장하기 위해 `id`가 없는 상태의 객체와 `id`가 부여된 상태의 객체를 각각 생성하는 방식이 괜찮은지 고민이 되었습니다. 저장 전과 저장 후의 상태를 이처럼 서로 다른 `Reservation` 객체로 표현해도 괜찮을지, 혹은 식별자를 다루는 더 적절한 방법이 있는지 궁금합니다.

### 2. `Clock`을 이용한 시간 의존성 처리

현재 시간을 직접 조회하는 대신 `Clock`을 `ReservationService`에 주입하여 시간의 기준을 외부에서 전달받을 수 있도록 구현하였습니다.

`Clock`을 공부하면서 시간이 단순히 `now()`를 호출해서 얻는 값이 아니라 테스트 관점에서는 외부에서 달라질 수 있는 의존성으로 볼 수도 있다는 점을 처음 접하게 되었습니다.

아직 `Clock`과 같은 시간 의존성을 다루는 방식이 익숙하지 않아 현재처럼 Service가 `Clock`을 주입받아 사용하는 구조가 적절한지와 실제 프로젝트에서는 시간에 의존하는 로직을 어떤 방식으로 관리하는지도 궁금합니다.

### 3. `MissionStepTest`의 값을 수정해도 괜찮을까요?

3, 4단계의 `MissionStepTest`를 실행하면서 기존 테스트의 값과 현재 구현이 맞지 않아 그대로는 정상적으로 동작하지 않는 부분이 있었습니다.

특히 현재보다 이전 일시는 예약할 수 없도록 검증하면서 기존 요구사항 테스트에서 사용하는 과거 날짜의 예약 요청이 실패하였습니다. 또한 현재 구현은 초기 예약 데이터가 존재하여 예약 생성 후 기대하는 예약 개수 및 ID가 맞지 않는 부분도 있었습니다.

전체 흐름을 확인하기 위해 테스트의 의도는 유지하면서 날짜와 기대하는 ID, 예약 개수 등의 값을 일부 수정하여 테스트하였는데, 
이처럼 기존 요구사항 테스트의 값이 현재 구현이나 추가한 정책과 충돌하는 경우에는 테스트의 의도를 유지하는 범위에서 값을 수정하여 진행해도 괜찮을지 궁금합니다.

---

추가적으로 앞서 DM으로 말씀드린 것처럼 8/21~23 기간 동안 리뷰 답변이 늦어질 수 있는 점 양해부탁드립니다. 🥲
긴 글 읽어주시고, 소중한 시간 내어 리뷰해주셔서 감사합니다!!